### PR TITLE
feat(network): backward-compatibility PacketProxy adapter

### DIFF
--- a/network/packet_proxy.go
+++ b/network/packet_proxy.go
@@ -15,60 +15,116 @@
 package network
 
 import (
+	"errors"
 	"net"
 	"net/netip"
+
+	"golang.getoutline.org/sdk/network/packetrelay"
 )
 
 // PacketProxy handles UDP traffic from the upstream network stack. The upstream network stack uses the NewSession
 // function to create a new UDP session that can send or receive UDP packets from PacketProxy.
 //
+// Deprecated: Use [PacketRelay] instead.
+//
 // Multiple goroutines can simultaneously invoke methods on a PacketProxy.
 type PacketProxy interface {
-	// NewSession function tells the PacketProxy that a new UDP socket session has been started (using socket as an
-	// example, a session will be started by calling the bind() function). The PacketProxy then creates a
-	// PacketRequestSender object to handle requests from this session, and it also uses the PacketResponseReceiver
-	// to send responses back to the upstream network stack.
-	//
-	// Note that it is possible for a session to receive UDP packets without sending any requests.
+	// NewSession function tells the PacketProxy that a new UDP socket session has been started.
+	// The PacketProxy then creates a PacketRequestSender object to handle requests from this session,
+	// and it also uses the PacketResponseReceiver to send responses back to the upstream network stack.
 	NewSession(PacketResponseReceiver) (PacketRequestSender, error)
 }
 
-// PacketRequestSender sends UDP request packets to the [PacketProxy]. It should be implemented by the [PacketProxy],
-// which must implement the WriteTo method to process the request packets. PacketRequestSender is typically called by
-// an upstream component (such as a network stack). After the Close method is called, there will be no more requests
-// sent to the sender, and all resources can be freed.
+// PacketRequestSender sends UDP request packets to the [PacketProxy].
 //
-// Multiple goroutines can simultaneously invoke methods on a PacketRequestSender.
+// Deprecated: Use [PacketSender] instead.
 type PacketRequestSender interface {
-	// WriteTo sends a UDP request packet to the PacketProxy. The packet is destined for the remote server identified
-	// by `destination` and the payload of the packet is stored in `p`. If `p` is empty, the request packet will be
-	// ignored. WriteTo returns the number of bytes written from `p` and any error encountered that caused the function
-	// to stop early.
-	//
-	// `p` must not be modified, and it must not be referenced after WriteTo returns.
+	// WriteTo sends a UDP request packet to the PacketProxy. The packet is destined for the remote server
+	// identified by `destination` and the payload of the packet is stored in `p`.
+	// WriteTo returns the number of bytes written from `p` and any error encountered.
 	WriteTo(p []byte, destination netip.AddrPort) (int, error)
 
-	// Close indicates that the sender is no longer accepting new requests. Any future attempts to call WriteTo on the
-	// sender will fail with ErrClosed.
+	// Close indicates that no more calls to WriteTo will be made.
 	Close() error
 }
 
-// PacketResponseReceiver receives UDP response packets from the [PacketProxy]. It is usually implemented by an
-// upstream component (such as a network stack). When a new UDP session is created, a valid instance of
-// PacketResponseReceiver is passed to the PacketProxy.NewSession function. The [PacketProxy] must then use this
-// instance to send UDP responses. It must then call the Close function to indicate that there will be no more
-// responses sent to this receiver.
+// PacketResponseReceiver receives UDP response packets from the [PacketProxy].
 //
-// Multiple goroutines can simultaneously invoke methods on a PacketResponseReceiver.
+// Deprecated: Use [PacketHandler] instead.
 type PacketResponseReceiver interface {
-	// WriteFrom is a callback function that is called by a PacketProxy when a UDP response packet is received. The
-	// `source` identifies the remote server that sent the packet and the `p` contains the packet payload. WriteFrom
-	// returns the number of bytes written from `p` and any error encountered that caused the function to stop early.
-	//
-	// `p` must not be modified, and it must not be referenced after WriteFrom returns.
+	// WriteFrom is a callback function that is called by a PacketProxy when a UDP response packet is received.
+	// The `source` identifies the remote server that sent the packet and the `p` contains the packet payload.
+	// WriteFrom returns the number of bytes written from `p` and any error encountered.
 	WriteFrom(p []byte, source net.Addr) (int, error)
 
-	// Close indicates that the receiver is no longer accepting new responses. Any future attempts to call WriteFrom on
-	// the receiver will fail with ErrClosed.
+	// Close indicates that no more calls to WriteFrom will be made.
 	Close() error
+}
+
+// NewPacketProxyFromPacketRelay adapts a [packetrelay.PacketRelay] to the [PacketProxy] interface.
+// This allows using new PacketRelay implementations where the old PacketProxy API is required.
+//
+// Deprecated: Use the new [packetrelay] API directly.
+func NewPacketProxyFromPacketRelay(relay packetrelay.PacketRelay) PacketProxy {
+	if relay == nil {
+		return nil
+	}
+	return &packetRelayToProxyAdapter{relay: relay}
+}
+
+type packetRelayToProxyAdapter struct {
+	relay packetrelay.PacketRelay
+}
+
+func (a *packetRelayToProxyAdapter) NewSession(respReceiver PacketResponseReceiver) (PacketRequestSender, error) {
+	if respReceiver == nil {
+		return nil, errors.New("respReceiver must not be nil")
+	}
+
+	sender, receiver, err := a.relay.NewAssociation()
+	if err != nil {
+		return nil, err
+	}
+
+	// Start the receive loop to push packets to respReceiver
+	go func() {
+		// When ReceivePackets returns, the stream has ended, so we close respReceiver.
+		_ = receiver.ReceivePackets(&packetHandlerAdapter{respReceiver: respReceiver})
+		_ = respReceiver.Close()
+	}()
+
+	return &packetSenderToRequestSenderAdapter{sender: sender}, nil
+}
+
+type packetHandlerAdapter struct {
+	respReceiver PacketResponseReceiver
+}
+
+func (h *packetHandlerAdapter) HandlePacket(p []byte, source netip.AddrPort) error {
+	// Convert netip.AddrPort to *net.UDPAddr for WriteFrom
+	_, err := h.respReceiver.WriteFrom(p, net.UDPAddrFromAddrPort(source))
+	return err
+}
+
+type packetSenderToRequestSenderAdapter struct {
+	sender packetrelay.PacketSender
+}
+
+func (s *packetSenderToRequestSenderAdapter) WriteTo(p []byte, destination netip.AddrPort) (int, error) {
+	err := s.sender.SendPacket(p, destination)
+	if err != nil {
+		if errors.Is(err, packetrelay.ErrClosed) {
+			return 0, ErrClosed
+		}
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func (s *packetSenderToRequestSenderAdapter) Close() error {
+	err := s.sender.Close()
+	if errors.Is(err, packetrelay.ErrClosed) {
+		return ErrClosed
+	}
+	return err
 }

--- a/network/packetrelay/delegate_packet_relay.go
+++ b/network/packetrelay/delegate_packet_relay.go
@@ -1,0 +1,74 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetrelay
+
+import (
+	"errors"
+	"sync/atomic"
+)
+
+// DelegatePacketRelay is a [PacketRelay] that forwards calls (like NewAssociation) to another [PacketRelay],
+// so that the caller can replace the underlying [PacketRelay] without changing the original reference.
+// To create a DelegatePacketRelay with the default PacketRelay, use [NewDelegatePacketRelay]. To change
+// the underlying [PacketRelay], use SetRelay.
+//
+// Note: After the underlying [PacketRelay] is changed, only new NewAssociation calls will be routed to the new
+// [PacketRelay]. Existing associations will not be affected.
+//
+// Multiple goroutines can simultaneously invoke methods on a DelegatePacketRelay.
+type DelegatePacketRelay interface {
+	PacketRelay
+
+	// SetRelay updates the underlying PacketRelay to `relay`; `relay` must not be nil. After this function
+	// returns, all new PacketRelay calls will be forwarded to the `relay`. Existing associations will not be affected.
+	SetRelay(relay PacketRelay) error
+}
+
+var errInvalidRelay = errors.New("the underlying relay must not be nil")
+
+// Compilation guard against interface implementation
+var _ DelegatePacketRelay = (*delegatePacketRelay)(nil)
+
+type delegatePacketRelay struct {
+	// The underlying PacketRelay when creating NewAssociation.
+	// Note that we must not use atomic.Value; otherwise TestSetRelayOfDifferentTypes will panic with
+	// "store inconsistently typed value".
+	relay atomic.Pointer[PacketRelay]
+}
+
+// NewDelegatePacketRelay creates a new [DelegatePacketRelay] that forwards calls to the `relay` [PacketRelay].
+// The `relay` must not be nil.
+func NewDelegatePacketRelay(relay PacketRelay) (DelegatePacketRelay, error) {
+	if relay == nil {
+		return nil, errInvalidRelay
+	}
+	dr := delegatePacketRelay{}
+	dr.relay.Store(&relay)
+	return &dr, nil
+}
+
+// NewAssociation implements PacketRelay.NewAssociation, and it will forward the call to the underlying PacketRelay.
+func (p *delegatePacketRelay) NewAssociation() (PacketSender, PacketReceiver, error) {
+	return (*p.relay.Load()).NewAssociation()
+}
+
+// SetRelay implements DelegatePacketRelay.SetRelay.
+func (p *delegatePacketRelay) SetRelay(relay PacketRelay) error {
+	if relay == nil {
+		return errInvalidRelay
+	}
+	p.relay.Store(&relay)
+	return nil
+}

--- a/network/packetrelay/delegate_packet_relay_test.go
+++ b/network/packetrelay/delegate_packet_relay_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetrelay
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Make sure the underlying packet relay can be initialized and updated
+func TestRelayCanBeUpdated(t *testing.T) {
+	defRelay := &sessionCountPacketRelay{}
+	newRelay := &sessionCountPacketRelay{}
+	p, err := NewDelegatePacketRelay(defRelay)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	// Initially no NewAssociation is called
+	require.Exactly(t, 0, defRelay.Count())
+	require.Exactly(t, 0, newRelay.Count())
+
+	snd, rcv, err := p.NewAssociation()
+	require.Nil(t, snd)
+	require.Nil(t, rcv)
+	require.NoError(t, err)
+
+	// defRelay.NewAssociation's count++
+	require.Exactly(t, 1, defRelay.Count())
+	require.Exactly(t, 0, newRelay.Count())
+
+	// SetRelay should not call NewAssociation
+	err = p.SetRelay(newRelay)
+	require.NoError(t, err)
+	require.Exactly(t, 1, defRelay.Count())
+	require.Exactly(t, 0, newRelay.Count())
+
+	// newRelay.NewAssociation's count += 2
+	snd, rcv, err = p.NewAssociation()
+	require.Nil(t, snd)
+	require.Nil(t, rcv)
+	require.NoError(t, err)
+
+	snd, rcv, err = p.NewAssociation()
+	require.Nil(t, snd)
+	require.Nil(t, rcv)
+	require.NoError(t, err)
+
+	require.Exactly(t, 1, defRelay.Count())
+	require.Exactly(t, 2, newRelay.Count())
+}
+
+// Make sure multiple goroutines can call NewAssociation and SetRelay concurrently
+// Need to run this test with `-race` flag
+func TestSetRelayRaceCondition(t *testing.T) {
+	const relaysCnt = 10
+	const sessionCntPerRelay = 5
+
+	var relays [relaysCnt]*sessionCountPacketRelay
+	for i := 0; i < relaysCnt; i++ {
+		relays[i] = &sessionCountPacketRelay{}
+	}
+
+	dr, err := NewDelegatePacketRelay(relays[0])
+	require.NotNil(t, dr)
+	require.NoError(t, err)
+
+	setRelayTask := &sync.WaitGroup{}
+	cancelSetRelay := &atomic.Bool{}
+	setRelayTask.Add(1)
+	go func() {
+		for i := 0; !cancelSetRelay.Load(); i = (i + 1) % relaysCnt {
+			err := dr.SetRelay(relays[i])
+			require.NoError(t, err)
+		}
+		setRelayTask.Done()
+	}()
+
+	newAssociationTask := &sync.WaitGroup{}
+	newAssociationTask.Add(1)
+	go func() {
+		for i := 0; i < relaysCnt*sessionCntPerRelay; i++ {
+			dr.NewAssociation()
+		}
+		newAssociationTask.Done()
+	}()
+
+	newAssociationTask.Wait()
+	cancelSetRelay.Store(true)
+	setRelayTask.Wait()
+
+	expectedTotal := relaysCnt * sessionCntPerRelay
+	actualTotal := 0
+	for i := 0; i < relaysCnt; i++ {
+		require.GreaterOrEqual(t, relays[i].Count(), 0)
+		actualTotal += relays[i].Count()
+	}
+	require.Equal(t, expectedTotal, actualTotal)
+}
+
+// Make sure we cannot SetRelay to nil
+func TestSetRelayWithNilValue(t *testing.T) {
+	// must not initialize with nil
+	dr, err := NewDelegatePacketRelay(nil)
+	require.Error(t, err)
+	require.Nil(t, dr)
+
+	dr, err = NewDelegatePacketRelay(&sessionCountPacketRelay{})
+	require.NoError(t, err)
+	require.NotNil(t, dr)
+
+	// must not SetRelay to nil
+	err = dr.SetRelay(nil)
+	require.Error(t, err)
+}
+
+// Make sure we can SetRelay to different types
+func TestSetRelayOfDifferentTypes(t *testing.T) {
+	defRelay := &sessionCountPacketRelay{}
+	newRelay := &noopPacketRelay{}
+
+	p, err := NewDelegatePacketRelay(defRelay)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	// SetRelay should not return error
+	err = p.SetRelay(newRelay)
+	require.NoError(t, err)
+
+	// NewAssociation should not go to defRelay
+	snd, rcv, err := p.NewAssociation()
+	require.Nil(t, snd)
+	require.Nil(t, rcv)
+	require.NoError(t, err)
+	require.Exactly(t, 0, defRelay.Count())
+}
+
+// sessionCountPacketRelay logs the count of the NewAssociation calls, and returns nil interfaces
+type sessionCountPacketRelay struct {
+	cnt atomic.Int32
+}
+
+func (sp *sessionCountPacketRelay) NewAssociation() (PacketSender, PacketReceiver, error) {
+	sp.cnt.Add(1)
+	return nil, nil, nil
+}
+
+func (sp *sessionCountPacketRelay) Count() int {
+	return int(sp.cnt.Load())
+}
+
+type noopPacketRelay struct{}
+
+func (noopPacketRelay) NewAssociation() (PacketSender, PacketReceiver, error) {
+	return nil, nil, nil
+}

--- a/network/packetrelay/lazy_packet_relay.go
+++ b/network/packetrelay/lazy_packet_relay.go
@@ -1,0 +1,158 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetrelay
+
+import (
+	"net/netip"
+	"sync"
+)
+
+type lazyPacketRelay struct {
+	inner PacketRelay
+}
+
+// NewLazyPacketRelay creates a decorator that defers calling NewAssociation
+// on the underlying inner relay until the first SendPacket or ReceivePackets call.
+func NewLazyPacketRelay(inner PacketRelay) PacketRelay {
+	if inner == nil {
+		return nil
+	}
+	return &lazyPacketRelay{inner: inner}
+}
+
+func (r *lazyPacketRelay) NewAssociation() (PacketSender, PacketReceiver, error) {
+	s := &lazyPacketSender{relay: r.inner}
+	rcv := &lazyPacketReceiver{sender: s}
+	s.receiver = rcv
+	return s, rcv, nil
+}
+
+type lazyPacketSender struct {
+	mu       sync.Mutex
+	relay    PacketRelay
+	inner    PacketSender
+	receiver *lazyPacketReceiver
+	closed   bool
+}
+
+func (s *lazyPacketSender) getInner() (PacketSender, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil, ErrClosed
+	}
+	if s.inner != nil {
+		return s.inner, nil
+	}
+	
+	// Establish association lazily
+	innerSender, innerReceiver, err := s.relay.NewAssociation()
+	if err != nil {
+		return nil, err
+	}
+	s.inner = innerSender
+	s.receiver.setInner(innerReceiver)
+	return s.inner, nil
+}
+
+func (s *lazyPacketSender) SendPacket(p []byte, destination netip.AddrPort) error {
+	inner, err := s.getInner()
+	if err != nil {
+		return err
+	}
+	return inner.SendPacket(p, destination)
+}
+
+func (s *lazyPacketSender) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return ErrClosed
+	}
+	s.closed = true
+	inner := s.inner
+	s.inner = nil
+	s.mu.Unlock()
+
+	// Unblock the lazy receiver if it was waiting and never initialized
+	s.receiver.cancelWait()
+
+	if inner != nil {
+		return inner.Close()
+	}
+	return nil
+}
+
+type lazyPacketReceiver struct {
+	mu       sync.Mutex
+	inner    PacketReceiver
+	sender   *lazyPacketSender
+	cond     *sync.Cond
+	canceled bool
+}
+
+func (r *lazyPacketReceiver) setInner(inner PacketReceiver) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.inner = inner
+	if r.cond != nil {
+		r.cond.Broadcast()
+	}
+}
+
+func (r *lazyPacketReceiver) cancelWait() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.canceled = true
+	if r.cond != nil {
+		r.cond.Broadcast()
+	}
+}
+
+func (r *lazyPacketReceiver) waitInner() (PacketReceiver, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.inner != nil {
+		return r.inner, nil
+	}
+	if r.canceled {
+		return nil, ErrClosed
+	}
+	
+	// Trigger lazy initialization via the sender
+	go func() {
+		_, _ = r.sender.getInner()
+	}()
+
+	if r.cond == nil {
+		r.cond = sync.NewCond(&r.mu)
+	}
+	for r.inner == nil && !r.canceled {
+		r.cond.Wait()
+	}
+	
+	if r.inner != nil {
+		return r.inner, nil
+	}
+	return nil, ErrClosed
+}
+
+func (r *lazyPacketReceiver) ReceivePackets(handler PacketHandler) error {
+	inner, err := r.waitInner()
+	if err != nil {
+		return err
+	}
+	return inner.ReceivePackets(handler)
+}

--- a/network/packetrelay/lazy_packet_relay_test.go
+++ b/network/packetrelay/lazy_packet_relay_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetrelay
+
+import (
+	"errors"
+	"net/netip"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLazyPacketRelay_Deferred(t *testing.T) {
+	mock := &mockSessionCountRelay{
+		closeSig: make(chan struct{}),
+	}
+	lazy := NewLazyPacketRelay(mock)
+
+	sender, receiver, err := lazy.NewAssociation()
+	require.NoError(t, err)
+	require.NotNil(t, sender)
+	require.NotNil(t, receiver)
+
+	// Association should NOT have been established on the mock yet
+	require.Equal(t, 0, mock.Count())
+
+	// First send triggers it
+	err = sender.SendPacket([]byte("hello"), netip.MustParseAddrPort("1.2.3.4:53"))
+	require.NoError(t, err)
+	require.Equal(t, 1, mock.Count())
+}
+
+func TestLazyPacketRelay_DeferredReceive(t *testing.T) {
+	mock := &mockSessionCountRelay{
+		closeSig: make(chan struct{}),
+	}
+	lazy := NewLazyPacketRelay(mock)
+
+	_, receiver, err := lazy.NewAssociation()
+	require.NoError(t, err)
+
+	// ReceivePackets blocks and triggers it
+	handler := &mockPacketHandler{}
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- receiver.ReceivePackets(handler)
+	}()
+
+	// Give scheduling latency a moment
+	time.Sleep(30 * time.Millisecond)
+	require.Equal(t, 1, mock.Count())
+}
+
+func TestLazyPacketRelay_CloseUnblock(t *testing.T) {
+	mock := &mockSessionCountRelay{
+		closeSig: make(chan struct{}),
+	}
+	lazy := NewLazyPacketRelay(mock)
+
+	sender, receiver, err := lazy.NewAssociation()
+	require.NoError(t, err)
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- receiver.ReceivePackets(&mockPacketHandler{})
+	}()
+
+	// Wait for condition and then close without sending
+	time.Sleep(30 * time.Millisecond)
+	require.NoError(t, sender.Close())
+
+	// ReceivePackets must cleanly unblock and exit with nil or ErrClosed
+	select {
+	case err := <-errChan:
+		require.True(t, err == nil || errors.Is(err, ErrClosed), "expected error to be nil or ErrClosed, got: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for ReceivePackets to unblock on close")
+	}
+}
+
+type mockSessionCountRelay struct {
+	cnt      atomic.Int32
+	closeSig chan struct{}
+}
+
+func (m *mockSessionCountRelay) NewAssociation() (PacketSender, PacketReceiver, error) {
+	m.cnt.Add(1)
+	
+	mockRelay := &mockPacketRelay{
+		closeSig: m.closeSig,
+	}
+	return &mockPacketSender{relay: mockRelay}, &mockPacketReceiver{relay: mockRelay}, nil
+}
+
+func (m *mockSessionCountRelay) Count() int {
+	return int(m.cnt.Load())
+}

--- a/network/packetrelay/packet_listener_relay.go
+++ b/network/packetrelay/packet_listener_relay.go
@@ -1,0 +1,158 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetrelay
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/netip"
+	"sync"
+
+	"golang.getoutline.org/sdk/internal/slicepool"
+	"golang.getoutline.org/sdk/transport"
+)
+
+// this was the buffer size used before, we may consider update it in the future
+const packetMaxSize = 2048
+
+// packetBufferPool is used to create buffers to read UDP response packets
+var packetBufferPool = slicepool.MakePool(packetMaxSize)
+
+// Compilation guard against interface implementation
+var _ PacketRelay = (*PacketListenerRelay)(nil)
+var _ PacketSender = (*packetListenerSender)(nil)
+var _ PacketReceiver = (*packetListenerReceiver)(nil)
+
+// PacketListenerRelay creates a new [PacketRelay] that uses the existing [transport.PacketListener] to
+// create connections to a relay.
+type PacketListenerRelay struct {
+	listener transport.PacketListener
+}
+
+// NewPacketRelayFromPacketListener creates a new [PacketRelay] that uses the existing [transport.PacketListener] to
+// create connections to a relay. You can also specify additional options.
+// This function is useful if you already have an implementation of [transport.PacketListener] and you want to use it
+// with one of the network stacks (for example, network/lwip2transport) as a UDP traffic handler.
+func NewPacketRelayFromPacketListener(pl transport.PacketListener, options ...func(*PacketListenerRelay) error) (*PacketListenerRelay, error) {
+	if pl == nil {
+		return nil, errors.New("pl must not be nil")
+	}
+	r := &PacketListenerRelay{
+		listener: pl,
+	}
+	for _, opt := range options {
+		if err := opt(r); err != nil {
+			return nil, err
+		}
+	}
+	return r, nil
+}
+
+// NewAssociation implements [PacketRelay].NewAssociation. It uses [transport.PacketListener].ListenPacket to create
+// a [net.PacketConn], and returns a [PacketSender] and [PacketReceiver] based on this [net.PacketConn].
+func (relay *PacketListenerRelay) NewAssociation() (PacketSender, PacketReceiver, error) {
+	packetConn, err := relay.listener.ListenPacket(context.Background())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sender := &packetListenerSender{
+		packetConn: packetConn,
+	}
+
+	receiver := &packetListenerReceiver{
+		packetConn: packetConn,
+	}
+
+	return sender, receiver, nil
+}
+
+type packetListenerSender struct {
+	mu     sync.Mutex // Protects closed flag
+	closed bool
+
+	packetConn net.PacketConn
+}
+
+// SendPacket implements [PacketSender].SendPacket. It simply forwards the packet to the underlying
+// [net.PacketConn].WriteTo function.
+func (s *packetListenerSender) SendPacket(p []byte, destination netip.AddrPort) error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return ErrClosed
+	}
+	packetConn := s.packetConn
+	s.mu.Unlock()
+
+	_, err := packetConn.WriteTo(p, net.UDPAddrFromAddrPort(destination))
+	return err
+}
+
+// Close implements [PacketSender].Close. It closes the underlying [net.PacketConn]. This will also
+// terminate the blocking loop in ReceivePackets because s.packetConn.ReadFrom will return an error.
+func (s *packetListenerSender) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return ErrClosed
+	}
+	s.closed = true
+	packetConn := s.packetConn
+	s.packetConn = nil
+	s.mu.Unlock()
+
+	return packetConn.Close()
+}
+
+type packetListenerReceiver struct {
+	packetConn net.PacketConn
+}
+
+// ReceivePackets implements [PacketReceiver].ReceivePackets. It blocks and passes incoming packets
+// from the relay to the handler.
+func (r *packetListenerReceiver) ReceivePackets(handler PacketHandler) error {
+	// Allocate buffer from slicepool
+	slice := packetBufferPool.LazySlice()
+	buf := slice.Acquire()
+	defer slice.Release()
+
+	for {
+		n, srcAddr, err := r.packetConn.ReadFrom(buf)
+		if err != nil {
+			if errors.Is(err, io.ErrShortBuffer) {
+				continue
+			}
+			return err
+		}
+
+		var srcPort netip.AddrPort
+		if udpAddr, ok := srcAddr.(*net.UDPAddr); ok {
+			srcPort = udpAddr.AddrPort()
+		} else {
+			var err error
+			srcPort, err = netip.ParseAddrPort(srcAddr.String())
+			if err != nil {
+				return err
+			}
+		}
+
+		if err := handler.HandlePacket(buf[:n], srcPort); err != nil {
+			return err
+		}
+	}
+}

--- a/network/packetrelay/packet_listener_relay_test.go
+++ b/network/packetrelay/packet_listener_relay_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetrelay
+
+import (
+	"testing"
+
+	"golang.getoutline.org/sdk/transport"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPacketRelayFromPacketListener(t *testing.T) {
+	pl := &transport.UDPListener{}
+
+	relay, err := NewPacketRelayFromPacketListener(pl)
+	require.NoError(t, err)
+	require.NotNil(t, relay)
+}

--- a/network/packetrelay/timeout_packet_relay.go
+++ b/network/packetrelay/timeout_packet_relay.go
@@ -1,0 +1,134 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetrelay
+
+import (
+	"errors"
+	"net/netip"
+	"sync"
+	"time"
+)
+
+// TimeoutPacketRelay is a [PacketRelay] decorator that manages an idle timeout for packet associations.
+// If no packets are sent for the specified duration, the association is closed.
+//
+// Note: To prevent Denial-of-Service (DoS) issues, the idle timer is ONLY reset on outgoing packets
+// ([PacketSender.SendPacket]) and NOT on incoming packets. This aligns with the recommendation in
+// RFC 4787 Section 4.3 (Mapping Refresh) to use unidirectional refresh to mitigate DoS attacks:
+// https://www.rfc-editor.org/rfc/rfc4787.html#section-4.3
+//
+// Multiple goroutines can simultaneously invoke methods on a TimeoutPacketRelay.
+type TimeoutPacketRelay struct {
+	inner   PacketRelay
+	timeout time.Duration
+}
+
+// NewTimeoutPacketRelay creates a new [TimeoutPacketRelay] wrapping `inner`.
+// The `timeout` must be greater than 0.
+func NewTimeoutPacketRelay(inner PacketRelay, timeout time.Duration) (*TimeoutPacketRelay, error) {
+	if inner == nil {
+		return nil, errors.New("inner relay must not be nil")
+	}
+	if timeout <= 0 {
+		return nil, errors.New("timeout must be greater than 0")
+	}
+	return &TimeoutPacketRelay{inner: inner, timeout: timeout}, nil
+}
+
+// NewAssociation implements [PacketRelay].NewAssociation. It creates a new association
+// and starts the idle timeout timer on the send path.
+func (r *TimeoutPacketRelay) NewAssociation() (PacketSender, PacketReceiver, error) {
+	sender, receiver, err := r.inner.NewAssociation()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tSender := &timeoutPacketSender{
+		inner:        sender,
+		timeout:      r.timeout,
+		lastActivity: time.Now(),
+	}
+
+	// Lock before starting AfterFunc because the checkTimeout callback
+	// accesses tSender.timer (via s.timer.Reset), and could theoretically
+	// execute before the assignment below completes.
+	tSender.mu.Lock()
+	tSender.timer = time.AfterFunc(r.timeout, tSender.checkTimeout)
+	tSender.mu.Unlock()
+
+	return tSender, receiver, nil
+}
+
+type timeoutPacketSender struct {
+	mu           sync.Mutex
+	closed       bool
+	inner        PacketSender
+	timer        *time.Timer
+	timeout      time.Duration
+	lastActivity time.Time
+}
+
+func (s *timeoutPacketSender) SendPacket(p []byte, destination netip.AddrPort) error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return ErrClosed
+	}
+	s.lastActivity = time.Now()
+	inner := s.inner
+	s.mu.Unlock()
+
+	return inner.SendPacket(p, destination)
+}
+
+func (s *timeoutPacketSender) checkTimeout() {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+
+	// We check the actual elapsed time since the last activity.
+	// This is necessary because a time.AfterFunc goroutine can be scheduled
+	// by the Go runtime but not yet executed when SendPacket is called. 
+	// If we just blindly closed the session here, the Close() would execute
+	// AFTER a successful SendPacket, leading to unexpected out-of-order
+	// behavior (a successful send immediately followed by a close).
+	elapsed := time.Since(s.lastActivity)
+	if elapsed >= s.timeout {
+		s.mu.Unlock()
+		_ = s.Close()
+		return
+	}
+
+	// Not expired yet! Reschedule for the remaining time.
+	s.timer.Reset(s.timeout - elapsed)
+	s.mu.Unlock()
+}
+
+func (s *timeoutPacketSender) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return ErrClosed
+	}
+	s.closed = true
+	s.timer.Stop()
+	inner := s.inner
+	s.inner = nil
+	s.mu.Unlock()
+
+	return inner.Close()
+}

--- a/network/packetrelay/timeout_packet_relay_test.go
+++ b/network/packetrelay/timeout_packet_relay_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetrelay
+
+import (
+	"net/netip"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeoutPacketRelay_Timeout(t *testing.T) {
+	mock := &mockPacketRelay{
+		closeSig: make(chan struct{}),
+	}
+	timeoutRelay, err := NewTimeoutPacketRelay(mock, 50*time.Millisecond)
+	require.NoError(t, err)
+
+	sender, receiver, err := timeoutRelay.NewAssociation()
+	require.NoError(t, err)
+	require.NotNil(t, sender)
+	require.NotNil(t, receiver)
+
+	// Start receiver loop
+	handler := &mockPacketHandler{}
+	go func() {
+		_ = receiver.ReceivePackets(handler)
+	}()
+
+	// Wait for timeout
+	time.Sleep(100 * time.Millisecond)
+
+	// Sender should be closed
+	err = sender.SendPacket([]byte("hello"), netip.MustParseAddrPort("1.2.3.4:53"))
+	require.ErrorIs(t, err, ErrClosed)
+
+	// Mock should have been closed
+	require.True(t, mock.isClosed())
+}
+
+func TestTimeoutPacketRelay_ResetOnSend(t *testing.T) {
+	mock := &mockPacketRelay{
+		closeSig: make(chan struct{}),
+	}
+	timeoutRelay, err := NewTimeoutPacketRelay(mock, 100*time.Millisecond)
+	require.NoError(t, err)
+
+	sender, receiver, err := timeoutRelay.NewAssociation()
+	require.NoError(t, err)
+
+	go func() {
+		_ = receiver.ReceivePackets(&mockPacketHandler{})
+	}()
+
+	// Send packets every 50ms (less than 100ms timeout)
+	for i := 0; i < 3; i++ {
+		time.Sleep(50 * time.Millisecond)
+		err = sender.SendPacket([]byte("hello"), netip.MustParseAddrPort("1.2.3.4:53"))
+		require.NoError(t, err)
+	}
+
+	// Now stop sending and wait for timeout
+	time.Sleep(150 * time.Millisecond)
+
+	err = sender.SendPacket([]byte("hello"), netip.MustParseAddrPort("1.2.3.4:53"))
+	require.ErrorIs(t, err, ErrClosed)
+}
+
+func TestTimeoutPacketRelay_NoResetOnReceive(t *testing.T) {
+	mock := &mockPacketRelay{
+		closeSig:    make(chan struct{}),
+		handlerChan: make(chan PacketHandler, 1),
+	}
+	timeoutRelay, err := NewTimeoutPacketRelay(mock, 100*time.Millisecond)
+	require.NoError(t, err)
+
+	sender, receiver, err := timeoutRelay.NewAssociation()
+	require.NoError(t, err)
+
+	go func() {
+		_ = receiver.ReceivePackets(&mockPacketHandler{})
+	}()
+
+	// Wait for the mock receiver to start and capture the handler
+	handler := <-mock.handlerChan
+
+	// Simulate receiving packets every 40ms (total time 120ms > 100ms timeout)
+	for i := 0; i < 3; i++ {
+		time.Sleep(40 * time.Millisecond)
+		err = handler.HandlePacket([]byte("reply"), netip.MustParseAddrPort("1.2.3.4:53"))
+		require.NoError(t, err)
+	}
+
+	// The timeout (100ms) should have fired by now, even though we were receiving packets.
+	err = sender.SendPacket([]byte("hello"), netip.MustParseAddrPort("1.2.3.4:53"))
+	require.ErrorIs(t, err, ErrClosed)
+}
+
+// Mock implementations
+
+type mockPacketRelay struct {
+	mu          sync.Mutex
+	closed      bool
+	closeSig    chan struct{}
+	handlerChan chan PacketHandler
+}
+
+func (m *mockPacketRelay) NewAssociation() (PacketSender, PacketReceiver, error) {
+	return &mockPacketSender{relay: m}, &mockPacketReceiver{relay: m}, nil
+}
+
+func (m *mockPacketRelay) isClosed() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.closed
+}
+
+func (m *mockPacketRelay) setClosed() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.closed {
+		m.closed = true
+		close(m.closeSig)
+	}
+}
+
+type mockPacketSender struct {
+	relay *mockPacketRelay
+}
+
+func (s *mockPacketSender) SendPacket(p []byte, dest netip.AddrPort) error {
+	if s.relay.isClosed() {
+		return ErrClosed
+	}
+	return nil
+}
+
+func (s *mockPacketSender) Close() error {
+	s.relay.setClosed()
+	return nil
+}
+
+type mockPacketReceiver struct {
+	relay *mockPacketRelay
+}
+
+func (r *mockPacketReceiver) ReceivePackets(handler PacketHandler) error {
+	if r.relay.handlerChan != nil {
+		r.relay.handlerChan <- handler
+	}
+	<-r.relay.closeSig
+	return nil
+}
+
+type mockPacketHandler struct{}
+
+func (h *mockPacketHandler) HandlePacket(p []byte, src netip.AddrPort) error {
+	return nil
+}


### PR DESCRIPTION
This PR introduces NewPacketProxyFromPacketRelay adapter in the root network package to bridge modern flow-based PacketRelay components cleanly to legacy PacketProxy dialers, maintaining 100ackwards compatibility.

### 🔗 Dependencies
- Depends on #600