### PR TITLE
feat(network): idle timeout PacketRelay decorator

### DIFF
--- a/network/packetrelay/timeout_packet_relay.go
+++ b/network/packetrelay/timeout_packet_relay.go
@@ -1,0 +1,134 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetrelay
+
+import (
+	"errors"
+	"net/netip"
+	"sync"
+	"time"
+)
+
+// TimeoutPacketRelay is a [PacketRelay] decorator that manages an idle timeout for packet associations.
+// If no packets are sent for the specified duration, the association is closed.
+//
+// Note: To prevent Denial-of-Service (DoS) issues, the idle timer is ONLY reset on outgoing packets
+// ([PacketSender.SendPacket]) and NOT on incoming packets. This aligns with the recommendation in
+// RFC 4787 Section 4.3 (Mapping Refresh) to use unidirectional refresh to mitigate DoS attacks:
+// https://www.rfc-editor.org/rfc/rfc4787.html#section-4.3
+//
+// Multiple goroutines can simultaneously invoke methods on a TimeoutPacketRelay.
+type TimeoutPacketRelay struct {
+	inner   PacketRelay
+	timeout time.Duration
+}
+
+// NewTimeoutPacketRelay creates a new [TimeoutPacketRelay] wrapping `inner`.
+// The `timeout` must be greater than 0.
+func NewTimeoutPacketRelay(inner PacketRelay, timeout time.Duration) (*TimeoutPacketRelay, error) {
+	if inner == nil {
+		return nil, errors.New("inner relay must not be nil")
+	}
+	if timeout <= 0 {
+		return nil, errors.New("timeout must be greater than 0")
+	}
+	return &TimeoutPacketRelay{inner: inner, timeout: timeout}, nil
+}
+
+// NewAssociation implements [PacketRelay].NewAssociation. It creates a new association
+// and starts the idle timeout timer on the send path.
+func (r *TimeoutPacketRelay) NewAssociation() (PacketSender, PacketReceiver, error) {
+	sender, receiver, err := r.inner.NewAssociation()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tSender := &timeoutPacketSender{
+		inner:        sender,
+		timeout:      r.timeout,
+		lastActivity: time.Now(),
+	}
+
+	// Lock before starting AfterFunc because the checkTimeout callback
+	// accesses tSender.timer (via s.timer.Reset), and could theoretically
+	// execute before the assignment below completes.
+	tSender.mu.Lock()
+	tSender.timer = time.AfterFunc(r.timeout, tSender.checkTimeout)
+	tSender.mu.Unlock()
+
+	return tSender, receiver, nil
+}
+
+type timeoutPacketSender struct {
+	mu           sync.Mutex
+	closed       bool
+	inner        PacketSender
+	timer        *time.Timer
+	timeout      time.Duration
+	lastActivity time.Time
+}
+
+func (s *timeoutPacketSender) SendPacket(p []byte, destination netip.AddrPort) error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return ErrClosed
+	}
+	s.lastActivity = time.Now()
+	inner := s.inner
+	s.mu.Unlock()
+
+	return inner.SendPacket(p, destination)
+}
+
+func (s *timeoutPacketSender) checkTimeout() {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+
+	// We check the actual elapsed time since the last activity.
+	// This is necessary because a time.AfterFunc goroutine can be scheduled
+	// by the Go runtime but not yet executed when SendPacket is called. 
+	// If we just blindly closed the session here, the Close() would execute
+	// AFTER a successful SendPacket, leading to unexpected out-of-order
+	// behavior (a successful send immediately followed by a close).
+	elapsed := time.Since(s.lastActivity)
+	if elapsed >= s.timeout {
+		s.mu.Unlock()
+		_ = s.Close()
+		return
+	}
+
+	// Not expired yet! Reschedule for the remaining time.
+	s.timer.Reset(s.timeout - elapsed)
+	s.mu.Unlock()
+}
+
+func (s *timeoutPacketSender) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return ErrClosed
+	}
+	s.closed = true
+	s.timer.Stop()
+	inner := s.inner
+	s.inner = nil
+	s.mu.Unlock()
+
+	return inner.Close()
+}

--- a/network/packetrelay/timeout_packet_relay_test.go
+++ b/network/packetrelay/timeout_packet_relay_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetrelay
+
+import (
+	"net/netip"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeoutPacketRelay_Timeout(t *testing.T) {
+	mock := &mockPacketRelay{
+		closeSig: make(chan struct{}),
+	}
+	timeoutRelay, err := NewTimeoutPacketRelay(mock, 50*time.Millisecond)
+	require.NoError(t, err)
+
+	sender, receiver, err := timeoutRelay.NewAssociation()
+	require.NoError(t, err)
+	require.NotNil(t, sender)
+	require.NotNil(t, receiver)
+
+	// Start receiver loop
+	handler := &mockPacketHandler{}
+	go func() {
+		_ = receiver.ReceivePackets(handler)
+	}()
+
+	// Wait for timeout
+	time.Sleep(100 * time.Millisecond)
+
+	// Sender should be closed
+	err = sender.SendPacket([]byte("hello"), netip.MustParseAddrPort("1.2.3.4:53"))
+	require.ErrorIs(t, err, ErrClosed)
+
+	// Mock should have been closed
+	require.True(t, mock.isClosed())
+}
+
+func TestTimeoutPacketRelay_ResetOnSend(t *testing.T) {
+	mock := &mockPacketRelay{
+		closeSig: make(chan struct{}),
+	}
+	timeoutRelay, err := NewTimeoutPacketRelay(mock, 100*time.Millisecond)
+	require.NoError(t, err)
+
+	sender, receiver, err := timeoutRelay.NewAssociation()
+	require.NoError(t, err)
+
+	go func() {
+		_ = receiver.ReceivePackets(&mockPacketHandler{})
+	}()
+
+	// Send packets every 50ms (less than 100ms timeout)
+	for i := 0; i < 3; i++ {
+		time.Sleep(50 * time.Millisecond)
+		err = sender.SendPacket([]byte("hello"), netip.MustParseAddrPort("1.2.3.4:53"))
+		require.NoError(t, err)
+	}
+
+	// Now stop sending and wait for timeout
+	time.Sleep(150 * time.Millisecond)
+
+	err = sender.SendPacket([]byte("hello"), netip.MustParseAddrPort("1.2.3.4:53"))
+	require.ErrorIs(t, err, ErrClosed)
+}
+
+func TestTimeoutPacketRelay_NoResetOnReceive(t *testing.T) {
+	mock := &mockPacketRelay{
+		closeSig:    make(chan struct{}),
+		handlerChan: make(chan PacketHandler, 1),
+	}
+	timeoutRelay, err := NewTimeoutPacketRelay(mock, 100*time.Millisecond)
+	require.NoError(t, err)
+
+	sender, receiver, err := timeoutRelay.NewAssociation()
+	require.NoError(t, err)
+
+	go func() {
+		_ = receiver.ReceivePackets(&mockPacketHandler{})
+	}()
+
+	// Wait for the mock receiver to start and capture the handler
+	handler := <-mock.handlerChan
+
+	// Simulate receiving packets every 40ms (total time 120ms > 100ms timeout)
+	for i := 0; i < 3; i++ {
+		time.Sleep(40 * time.Millisecond)
+		err = handler.HandlePacket([]byte("reply"), netip.MustParseAddrPort("1.2.3.4:53"))
+		require.NoError(t, err)
+	}
+
+	// The timeout (100ms) should have fired by now, even though we were receiving packets.
+	err = sender.SendPacket([]byte("hello"), netip.MustParseAddrPort("1.2.3.4:53"))
+	require.ErrorIs(t, err, ErrClosed)
+}
+
+// Mock implementations
+
+type mockPacketRelay struct {
+	mu          sync.Mutex
+	closed      bool
+	closeSig    chan struct{}
+	handlerChan chan PacketHandler
+}
+
+func (m *mockPacketRelay) NewAssociation() (PacketSender, PacketReceiver, error) {
+	return &mockPacketSender{relay: m}, &mockPacketReceiver{relay: m}, nil
+}
+
+func (m *mockPacketRelay) isClosed() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.closed
+}
+
+func (m *mockPacketRelay) setClosed() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.closed {
+		m.closed = true
+		close(m.closeSig)
+	}
+}
+
+type mockPacketSender struct {
+	relay *mockPacketRelay
+}
+
+func (s *mockPacketSender) SendPacket(p []byte, dest netip.AddrPort) error {
+	if s.relay.isClosed() {
+		return ErrClosed
+	}
+	return nil
+}
+
+func (s *mockPacketSender) Close() error {
+	s.relay.setClosed()
+	return nil
+}
+
+type mockPacketReceiver struct {
+	relay *mockPacketRelay
+}
+
+func (r *mockPacketReceiver) ReceivePackets(handler PacketHandler) error {
+	if r.relay.handlerChan != nil {
+		r.relay.handlerChan <- handler
+	}
+	<-r.relay.closeSig
+	return nil
+}
+
+type mockPacketHandler struct{}
+
+func (h *mockPacketHandler) HandlePacket(p []byte, src netip.AddrPort) error {
+	return nil
+}


### PR DESCRIPTION
This PR layers optional timeout behavior using TimeoutPacketRelay. It safely manages standard time.AfterFunc/Reset races via a high-performance lastActivity timestamp and mitigates Denial-of-Service (DoS) risks via standard RFC 4787 Section 4.3 unidirectional mapping refreshes.

### 🔗 Dependencies
- Depends on #602