### PR TITLE
feat(network): deferred association LazyPacketRelay decorator

### DIFF
--- a/network/packetrelay/lazy_packet_relay.go
+++ b/network/packetrelay/lazy_packet_relay.go
@@ -1,0 +1,158 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetrelay
+
+import (
+	"net/netip"
+	"sync"
+)
+
+type lazyPacketRelay struct {
+	inner PacketRelay
+}
+
+// NewLazyPacketRelay creates a decorator that defers calling NewAssociation
+// on the underlying inner relay until the first SendPacket or ReceivePackets call.
+func NewLazyPacketRelay(inner PacketRelay) PacketRelay {
+	if inner == nil {
+		return nil
+	}
+	return &lazyPacketRelay{inner: inner}
+}
+
+func (r *lazyPacketRelay) NewAssociation() (PacketSender, PacketReceiver, error) {
+	s := &lazyPacketSender{relay: r.inner}
+	rcv := &lazyPacketReceiver{sender: s}
+	s.receiver = rcv
+	return s, rcv, nil
+}
+
+type lazyPacketSender struct {
+	mu       sync.Mutex
+	relay    PacketRelay
+	inner    PacketSender
+	receiver *lazyPacketReceiver
+	closed   bool
+}
+
+func (s *lazyPacketSender) getInner() (PacketSender, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil, ErrClosed
+	}
+	if s.inner != nil {
+		return s.inner, nil
+	}
+	
+	// Establish association lazily
+	innerSender, innerReceiver, err := s.relay.NewAssociation()
+	if err != nil {
+		return nil, err
+	}
+	s.inner = innerSender
+	s.receiver.setInner(innerReceiver)
+	return s.inner, nil
+}
+
+func (s *lazyPacketSender) SendPacket(p []byte, destination netip.AddrPort) error {
+	inner, err := s.getInner()
+	if err != nil {
+		return err
+	}
+	return inner.SendPacket(p, destination)
+}
+
+func (s *lazyPacketSender) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return ErrClosed
+	}
+	s.closed = true
+	inner := s.inner
+	s.inner = nil
+	s.mu.Unlock()
+
+	// Unblock the lazy receiver if it was waiting and never initialized
+	s.receiver.cancelWait()
+
+	if inner != nil {
+		return inner.Close()
+	}
+	return nil
+}
+
+type lazyPacketReceiver struct {
+	mu       sync.Mutex
+	inner    PacketReceiver
+	sender   *lazyPacketSender
+	cond     *sync.Cond
+	canceled bool
+}
+
+func (r *lazyPacketReceiver) setInner(inner PacketReceiver) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.inner = inner
+	if r.cond != nil {
+		r.cond.Broadcast()
+	}
+}
+
+func (r *lazyPacketReceiver) cancelWait() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.canceled = true
+	if r.cond != nil {
+		r.cond.Broadcast()
+	}
+}
+
+func (r *lazyPacketReceiver) waitInner() (PacketReceiver, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.inner != nil {
+		return r.inner, nil
+	}
+	if r.canceled {
+		return nil, ErrClosed
+	}
+	
+	// Trigger lazy initialization via the sender
+	go func() {
+		_, _ = r.sender.getInner()
+	}()
+
+	if r.cond == nil {
+		r.cond = sync.NewCond(&r.mu)
+	}
+	for r.inner == nil && !r.canceled {
+		r.cond.Wait()
+	}
+	
+	if r.inner != nil {
+		return r.inner, nil
+	}
+	return nil, ErrClosed
+}
+
+func (r *lazyPacketReceiver) ReceivePackets(handler PacketHandler) error {
+	inner, err := r.waitInner()
+	if err != nil {
+		return err
+	}
+	return inner.ReceivePackets(handler)
+}

--- a/network/packetrelay/lazy_packet_relay_test.go
+++ b/network/packetrelay/lazy_packet_relay_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetrelay
+
+import (
+	"errors"
+	"net/netip"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLazyPacketRelay_Deferred(t *testing.T) {
+	mock := &mockSessionCountRelay{
+		closeSig: make(chan struct{}),
+	}
+	lazy := NewLazyPacketRelay(mock)
+
+	sender, receiver, err := lazy.NewAssociation()
+	require.NoError(t, err)
+	require.NotNil(t, sender)
+	require.NotNil(t, receiver)
+
+	// Association should NOT have been established on the mock yet
+	require.Equal(t, 0, mock.Count())
+
+	// First send triggers it
+	err = sender.SendPacket([]byte("hello"), netip.MustParseAddrPort("1.2.3.4:53"))
+	require.NoError(t, err)
+	require.Equal(t, 1, mock.Count())
+}
+
+func TestLazyPacketRelay_DeferredReceive(t *testing.T) {
+	mock := &mockSessionCountRelay{
+		closeSig: make(chan struct{}),
+	}
+	lazy := NewLazyPacketRelay(mock)
+
+	_, receiver, err := lazy.NewAssociation()
+	require.NoError(t, err)
+
+	// ReceivePackets blocks and triggers it
+	handler := &mockPacketHandler{}
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- receiver.ReceivePackets(handler)
+	}()
+
+	// Give scheduling latency a moment
+	time.Sleep(30 * time.Millisecond)
+	require.Equal(t, 1, mock.Count())
+}
+
+func TestLazyPacketRelay_CloseUnblock(t *testing.T) {
+	mock := &mockSessionCountRelay{
+		closeSig: make(chan struct{}),
+	}
+	lazy := NewLazyPacketRelay(mock)
+
+	sender, receiver, err := lazy.NewAssociation()
+	require.NoError(t, err)
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- receiver.ReceivePackets(&mockPacketHandler{})
+	}()
+
+	// Wait for condition and then close without sending
+	time.Sleep(30 * time.Millisecond)
+	require.NoError(t, sender.Close())
+
+	// ReceivePackets must cleanly unblock and exit with nil or ErrClosed
+	select {
+	case err := <-errChan:
+		require.True(t, err == nil || errors.Is(err, ErrClosed), "expected error to be nil or ErrClosed, got: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for ReceivePackets to unblock on close")
+	}
+}
+
+type mockSessionCountRelay struct {
+	cnt      atomic.Int32
+	closeSig chan struct{}
+}
+
+func (m *mockSessionCountRelay) NewAssociation() (PacketSender, PacketReceiver, error) {
+	m.cnt.Add(1)
+	
+	mockRelay := &mockPacketRelay{
+		closeSig: m.closeSig,
+	}
+	return &mockPacketSender{relay: mockRelay}, &mockPacketReceiver{relay: mockRelay}, nil
+}
+
+func (m *mockSessionCountRelay) Count() int {
+	return int(m.cnt.Load())
+}


### PR DESCRIPTION
This PR introduces the LazyPacketRelay decorator that defers NewAssociation remote setups under the hood until the first packet is sent or receiving starts. Spawns condition-synchronized goroutine tear-downs preventing concurrent locks.

### 🔗 Dependencies
- Depends on #603