### PR TITLE
refactor(network): refactor local DNS fallback to implement modern PacketRelay

### DIFF
--- a/network/dnstruncate/packet_proxy.go
+++ b/network/dnstruncate/packet_proxy.go
@@ -17,12 +17,11 @@ package dnstruncate
 import (
 	"errors"
 	"fmt"
-	"net"
 	"net/netip"
-	"sync/atomic"
+	"sync"
 
-	"golang.getoutline.org/sdk/internal/slicepool"
 	"golang.getoutline.org/sdk/network"
+	"golang.getoutline.org/sdk/network/packetrelay"
 )
 
 // From [RFC 1035], the DNS message header contains the following fields:
@@ -61,94 +60,130 @@ const (
 	dnsARCntEndByte    = 7           // The ending byte (inclusive) of ANCOUNT
 )
 
-// packetBufferPool is used to create buffers to modify DNS requests
-var packetBufferPool = slicepool.MakePool(dnsUdpMaxMsgLen)
-
-// dnsTruncateProxy is a network.PacketProxy that create dnsTruncateRequestHandler to handle DNS requests locally.
+// dnsTruncateProxy is a network.PacketRelay that creates dnsTruncateSender to handle DNS requests locally.
 //
 // Multiple goroutines may invoke methods on a dnsTruncateProxy simultaneously.
-type dnsTruncateProxy struct {
+type dnsTruncateProxy struct{}
+
+type dnsPacket struct {
+	payload []byte
+	source  netip.AddrPort
 }
 
-// dnsTruncateRequestHandler is a network.PacketRequestSender that handles DNS requests in UDP protocol locally,
+// dnsTruncateSender is a network.PacketSender that handles DNS requests in UDP protocol locally,
 // without sending the requests to the actual DNS resolver. It sets the TC (truncated) bit in the DNS response header
 // to tell the caller to resend the DNS request over TCP.
-//
-// Multiple goroutines may invoke methods on a dnsTruncateProxy simultaneously.
-type dnsTruncateRequestHandler struct {
-	closed     atomic.Bool
-	respWriter network.PacketResponseReceiver
+type dnsTruncateSender struct {
+	mu     sync.Mutex
+	closed bool
+	ch     chan dnsPacket
+}
+
+type dnsTruncateReceiver struct {
+	ch chan dnsPacket
 }
 
 // Compilation guard against interface implementation
-var _ network.PacketProxy = (*dnsTruncateProxy)(nil)
-var _ network.PacketRequestSender = (*dnsTruncateRequestHandler)(nil)
+var _ packetrelay.PacketRelay = (*dnsTruncateProxy)(nil)
+var _ packetrelay.PacketSender = (*dnsTruncateSender)(nil)
+var _ packetrelay.PacketReceiver = (*dnsTruncateReceiver)(nil)
+
+// NewPacketRelay creates a new [packetrelay.PacketRelay] that can be used to handle DNS requests if the remote proxy
+// doesn't support UDP traffic. It sets the TC (truncated) bit in the DNS response header to tell the caller to resend
+// the DNS request over TCP.
+//
+// This [packetrelay.PacketRelay] should only be used if the remote proxy server doesn't support UDP traffic at all. Note
+// that all other non-DNS UDP packets will be dropped by this [packetrelay.PacketRelay].
+func NewPacketRelay() (packetrelay.PacketRelay, error) {
+	return &dnsTruncateProxy{}, nil
+}
 
 // NewPacketProxy creates a new [network.PacketProxy] that can be used to handle DNS requests if the remote proxy
 // doesn't support UDP traffic. It sets the TC (truncated) bit in the DNS response header to tell the caller to resend
 // the DNS request over TCP.
 //
-// This [network.PacketProxy] should only be used if the remote proxy server doesn't support UDP traffic at all. Note
-// that all other non-DNS UDP packets will be dropped by this [network.PacketProxy].
+// Deprecated: Use [NewPacketRelay] instead.
 func NewPacketProxy() (network.PacketProxy, error) {
-	return &dnsTruncateProxy{}, nil
+	relay, err := NewPacketRelay()
+	if err != nil {
+		return nil, err
+	}
+	return network.NewPacketProxyFromPacketRelay(relay), nil
 }
 
-// NewSession implements [network.PacketProxy].NewSession(). It creates a new [network.PacketRequestSender] that will
-// set the TC (truncated) bit and write the response to `respWriter`.
-func (p *dnsTruncateProxy) NewSession(respWriter network.PacketResponseReceiver) (network.PacketRequestSender, error) {
-	if respWriter == nil {
-		return nil, errors.New("respWriter is required")
+// NewAssociation implements [packetrelay.PacketRelay].NewAssociation(). It creates a new [packetrelay.PacketSender] and
+// [packetrelay.PacketReceiver] that will set the TC (truncated) bit on incoming DNS requests and yield the response.
+func (p *dnsTruncateProxy) NewAssociation() (packetrelay.PacketSender, packetrelay.PacketReceiver, error) {
+	// Buffer size of 16 is a reasonable trade-off for local DNS truncation
+	ch := make(chan dnsPacket, 16)
+	sender := &dnsTruncateSender{
+		ch: ch,
 	}
-	return &dnsTruncateRequestHandler{
-		respWriter: respWriter,
-	}, nil
+	receiver := &dnsTruncateReceiver{
+		ch: ch,
+	}
+	return sender, receiver, nil
 }
 
-// Close implements [network.PacketRequestSender].Close(), and it closes the corresponding
-// [network.PacketResponseReceiver].
-func (h *dnsTruncateRequestHandler) Close() error {
-	if !h.closed.CompareAndSwap(false, true) {
-		return network.ErrClosed
+// Close implements [packetrelay.PacketSender].Close(), and it closes the corresponding
+// [packetrelay.PacketReceiver] channel.
+func (s *dnsTruncateSender) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return packetrelay.ErrClosed
 	}
-	h.respWriter.Close()
+	s.closed = true
+	close(s.ch)
 	return nil
 }
 
-// WriteTo implements [network.PacketRequestSender].WriteTo(). It parses a packet from p, and determines whether it is
-// a valid DNS request. If so, it will write the DNS response with TC (truncated) bit set to the corresponding
-// [network.PacketResponseReceiver] passed to NewSession. If it is not a valid DNS request, the packet will be
-// discarded and returns an error.
-func (h *dnsTruncateRequestHandler) WriteTo(p []byte, destination netip.AddrPort) (int, error) {
-	if h.closed.Load() {
-		return 0, network.ErrClosed
+// SendPacket implements [packetrelay.PacketSender].SendPacket(). It parses a packet from p, and determines whether it is
+// a valid DNS request. If so, it will push a DNS response with TC (truncated) bit set to the receiver.
+func (s *dnsTruncateSender) SendPacket(p []byte, destination netip.AddrPort) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return packetrelay.ErrClosed
 	}
+
 	if destination.Port() != standardDNSPort {
-		return 0, fmt.Errorf("UDP traffic to non-DNS port %v is not supported: %w", destination.Port(), network.ErrPortUnreachable)
+		return fmt.Errorf("UDP traffic to non-DNS port %v is not supported: %w", destination.Port(), network.ErrPortUnreachable)
 	}
 	if len(p) < dnsUdpMinMsgLen {
-		return 0, fmt.Errorf("invalid DNS message of length %v, it must be at least %v bytes", len(p), dnsUdpMinMsgLen)
+		return fmt.Errorf("invalid DNS message of length %v, it must be at least %v bytes", len(p), dnsUdpMinMsgLen)
 	}
 
-	// Allocate buffer from slicepool, because `go build -gcflags="-m"` shows a local array will escape to heap
-	slice := packetBufferPool.LazySlice()
-	buf := slice.Acquire()
-	defer slice.Release()
-
-	// We need to copy p into buf because "WriteTo must not modify p, even temporarily".
-	n := copy(buf, p)
+	// We need to copy p into a new buffer because we pass it through a channel
+	buf := make([]byte, len(p))
+	copy(buf, p)
 
 	// Set "Response", "Truncated" and "NoError"
-	// Note: gopacket is a good library doing this kind of things. But it will increase the binary size a lot.
-	//       If we decide to use gopacket in the future, please evaluate the binary size and runtime memory consumption.
 	buf[dnsUdpAnswerByte] |= (dnsUdpResponseBit | dnsUdpTruncatedBit)
 	buf[dnsUdpRCodeByte] &= ^dnsUdpRCodeMask
 
 	// Copy QDCOUNT to ANCOUNT. This is an incorrect workaround for some DNS clients (such as Windows 7);
 	// because without these clients won't retry over TCP.
-	//
-	// For reference: https://github.com/eycorsican/go-tun2socks/blob/master/proxy/dnsfallback/udp.go#L59-L63
 	copy(buf[dnsARCntStartByte:dnsARCntEndByte+1], buf[dnsQDCntStartByte:dnsQDCntEndByte+1])
 
-	return h.respWriter.WriteFrom(buf[:n], net.UDPAddrFromAddrPort(destination))
+	// Push to channel inside the lock using select with default to avoid deadlocks
+	select {
+	case s.ch <- dnsPacket{payload: buf, source: destination}:
+		return nil
+	default:
+		// Queue is full!
+		return errors.New("DNS truncation queue full")
+	}
+}
+
+// ReceivePackets implements [packetrelay.PacketReceiver].ReceivePackets. It blocks and passes incoming DNS responses
+// to the handler.
+func (r *dnsTruncateReceiver) ReceivePackets(handler packetrelay.PacketHandler) error {
+	for pkt := range r.ch {
+		if err := handler.HandlePacket(pkt.payload, pkt.source); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/network/dnstruncate/packet_proxy_test.go
+++ b/network/dnstruncate/packet_proxy_test.go
@@ -15,13 +15,15 @@
 package dnstruncate
 
 import (
+	"errors"
 	"fmt"
-	"net"
 	"net/netip"
 	"sync"
 	"testing"
+	"time"
 
 	"golang.getoutline.org/sdk/network"
+	"golang.getoutline.org/sdk/network/packetrelay"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/stretchr/testify/require"
@@ -53,7 +55,7 @@ func TestInvalidDNSRequestReturnsError(t *testing.T) {
 	dnsReq := constructDNSRequestOrResponse(t, false, 0x2345, []string{"www.google.com"})
 	_, err := session.Query(dnsReq[:11], resolverAddr)
 	require.Error(t, err)
-	session.AssertNoResponseFrom(net.UDPAddrFromAddrPort(resolverAddr))
+	session.AssertNoResponseFrom(resolverAddr)
 
 	// minimum valid dns request size
 	dnsResp, err := session.Query(dnsReq[:12], resolverAddr)
@@ -82,13 +84,13 @@ func TestPacketNotSentToPort53ReturnsError(t *testing.T) {
 		resp, err := session.Query(dnsReq, resolverAddr)
 		require.ErrorIs(t, err, network.ErrPortUnreachable)
 		require.Nil(t, resp)
-		session.AssertNoResponseFrom(net.UDPAddrFromAddrPort(resolverAddr))
+		session.AssertNoResponseFrom(resolverAddr)
 	}
 
 	require.NoError(t, session.Close())
 }
 
-// Make sure WriteTo a closed proxy should result in an error
+// Make sure SendPacket to a closed proxy should result in an error
 func TestWriteToClosedProxyReturnsError(t *testing.T) {
 	session := newInstantDNSSessionForTest(t)
 	resolverAddr := netip.MustParseAddrPort("1.2.3.4:53")
@@ -97,20 +99,21 @@ func TestWriteToClosedProxyReturnsError(t *testing.T) {
 	require.NoError(t, session.Close())
 	dnsReq := constructDNSRequestOrResponse(t, false, 0x4567, []string{"www.google.com"})
 	resp, err := session.Query(dnsReq, resolverAddr)
-	require.ErrorIs(t, err, network.ErrClosed)
+	require.ErrorIs(t, err, packetrelay.ErrClosed)
 	require.Nil(t, resp)
-	session.AssertNoResponseFrom(net.UDPAddrFromAddrPort(resolverAddr))
+	session.AssertNoResponseFrom(resolverAddr)
 }
 
-// Make sure NewSession returns an error for nil PacketResponseReceiver
-func TestNewSessionWithNilResponseWriterReturnsError(t *testing.T) {
+// Make sure NewAssociation returns valid interfaces
+func TestNewAssociationReturnsValidInterfaces(t *testing.T) {
 	p := createProxyForTest(t)
-	s, err := p.NewSession(nil)
-	require.Error(t, err)
-	require.Nil(t, s)
+	sender, receiver, err := p.NewAssociation()
+	require.NoError(t, err)
+	require.NotNil(t, sender)
+	require.NotNil(t, receiver)
 }
 
-// Make sure multiple goroutines can call WriteTo to the same session
+// Make sure multiple goroutines can call SendPacket to the same session
 func TestMultipleWriteToRaceCondition(t *testing.T) {
 	const clientCnt = 20
 	const iterationCntPerClient = 20
@@ -143,8 +146,8 @@ func TestMultipleWriteToRaceCondition(t *testing.T) {
 
 /********** Test utilities **********/
 
-func createProxyForTest(t *testing.T) network.PacketProxy {
-	p, err := NewPacketProxy()
+func createProxyForTest(t *testing.T) packetrelay.PacketRelay {
+	p, err := NewPacketRelay()
 	require.NoError(t, err)
 	require.NotNil(t, p)
 	return p
@@ -208,12 +211,19 @@ func constructDNSRequestOrResponse(t *testing.T, response bool, id uint16, quest
 	return buf.Bytes()
 }
 
+type dnsResponseState struct {
+	ch       chan []byte
+	received bool
+}
+
 // instantPacketSession sends UDP request, and return the response instantly (see Query).
-// So it only works for local PacketProxy, but not remote ones.
 type instantPacketSession struct {
 	t         *testing.T
-	sender    network.PacketRequestSender
-	responses sync.Map // server addr -> response slice
+	sender    packetrelay.PacketSender
+	receiver  packetrelay.PacketReceiver
+	responses sync.Map // server addr (string) -> *dnsResponseState
+	closed    bool
+	mu        sync.Mutex
 }
 
 func newInstantDNSSessionForTest(t *testing.T) *instantPacketSession {
@@ -221,48 +231,70 @@ func newInstantDNSSessionForTest(t *testing.T) *instantPacketSession {
 	s := &instantPacketSession{
 		t: t,
 	}
-	sender, err := p.NewSession(s)
+	sender, receiver, err := p.NewAssociation()
 	require.NoError(t, err)
 	require.NotNil(t, sender)
+	require.NotNil(t, receiver)
 	s.sender = sender
+	s.receiver = receiver
+
+	// Start the receive loop
+	go func() {
+		_ = s.receiver.ReceivePackets(s)
+	}()
+
 	return s
 }
 
 func (s *instantPacketSession) Query(req []byte, dest netip.AddrPort) ([]byte, error) {
-	n, err := s.sender.WriteTo(req, dest)
+	ch := make(chan []byte, 1)
+	s.responses.Store(dest.String(), &dnsResponseState{ch: ch})
+
+	err := s.sender.SendPacket(req, dest)
 	if err != nil {
-		require.Exactly(s.t, 0, n)
 		return nil, err
 	}
-	if len(req) < dnsUdpMaxMsgLen {
-		require.Exactly(s.t, len(req), n)
-	} else {
-		require.Exactly(s.t, dnsUdpMaxMsgLen, n)
-	}
 
-	resp, ok := s.responses.Load(dest.String())
-	require.True(s.t, ok)
-	require.NotNil(s.t, resp)
-	return resp.([]byte), nil
+	// Wait for response with timeout
+	select {
+	case resp := <-ch:
+		return resp, nil
+	case <-time.After(2 * time.Second):
+		return nil, errors.New("timeout waiting for DNS response")
+	}
 }
 
-func (s *instantPacketSession) AssertNoResponseFrom(source net.Addr) {
-	resp, ok := s.responses.Load(source.String())
-	require.False(s.t, ok)
-	require.Nil(s.t, resp)
+func (s *instantPacketSession) AssertNoResponseFrom(source netip.AddrPort) {
+	// Wait a bit to ensure no packet arrives asynchronously
+	time.Sleep(50 * time.Millisecond)
+	stateObj, ok := s.responses.Load(source.String())
+	if !ok {
+		return
+	}
+	state := stateObj.(*dnsResponseState)
+	require.False(s.t, state.received)
 }
 
 func (s *instantPacketSession) Close() error {
-	return s.sender.Close()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.closed {
+		s.closed = true
+		return s.sender.Close()
+	}
+	return nil
 }
 
-func (s *instantPacketSession) WriteFrom(p []byte, source net.Addr) (int, error) {
-	require.LessOrEqual(s.t, len(p), dnsUdpMaxMsgLen)
-
-	buf := make([]byte, dnsUdpMaxMsgLen)
-	n := copy(buf, p)
-	require.LessOrEqual(s.t, n, dnsUdpMaxMsgLen)
-
-	s.responses.Store(source.String(), buf[:n])
-	return n, nil
+func (s *instantPacketSession) HandlePacket(p []byte, source netip.AddrPort) error {
+	if stateObj, ok := s.responses.Load(source.String()); ok {
+		state := stateObj.(*dnsResponseState)
+		state.received = true
+		buf := make([]byte, len(p))
+		copy(buf, p)
+		select {
+		case state.ch <- buf:
+		default:
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
This PR refactors the local DNS truncate proxy in the dnstruncate subpackage to natively implement the new PacketRelay API, pushing to a non-blocking select queue to avoid deadlock risks when sending under concurrent locks.

### 🔗 Dependencies
- Depends on #605