### PR TITLE
refactor(network): native ConfigureDeviceWithRelay in lwip2transport

### DIFF
--- a/network/lwip2transport/device.go
+++ b/network/lwip2transport/device.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"golang.getoutline.org/sdk/network"
+	"golang.getoutline.org/sdk/network/packetrelay"
 	"golang.getoutline.org/sdk/transport"
 	lwip "github.com/eycorsican/go-tun2socks/core"
 )
@@ -31,7 +32,7 @@ var _ network.IPDevice = (*lwIPDevice)(nil)
 
 type lwIPDevice struct {
 	tcp   *tcpHandler
-	udp   *udpHandler
+	udp   lwip.UDPConnHandler
 	stack lwip.LWIPStack
 
 	// whether the device has been closed
@@ -80,6 +81,36 @@ func ConfigureDevice(sd transport.StreamDialer, pp network.PacketProxy) (network
 	inst = &lwIPDevice{
 		tcp:   newTCPHandler(sd),
 		udp:   newUDPHandler(pp),
+		stack: lwip.NewLWIPStack(),
+		done:  make(chan struct{}),
+		rdBuf: make(chan []byte),
+		rdN:   make(chan int),
+	}
+	lwip.RegisterTCPConnHandler(inst.tcp)
+	lwip.RegisterUDPConnHandler(inst.udp)
+	lwip.RegisterOutputFn(inst.forwardOutgoingIPPacket)
+
+	return inst, nil
+}
+
+// ConfigureDeviceWithRelay configures the singleton LwIP device using the [transport.StreamDialer] to handle TCP streams and
+// the [packetrelay.PacketRelay] to handle UDP packets.
+//
+// This is the modernized equivalent of [ConfigureDevice], allowing native adoption of the flow-based PacketRelay API.
+func ConfigureDeviceWithRelay(sd transport.StreamDialer, pr packetrelay.PacketRelay) (network.IPDevice, error) {
+	if sd == nil || pr == nil {
+		return nil, errors.New("both sd and pr are required")
+	}
+
+	instMu.Lock()
+	defer instMu.Unlock()
+
+	if inst != nil {
+		inst.Close()
+	}
+	inst = &lwIPDevice{
+		tcp:   newTCPHandler(sd),
+		udp:   newUDPRelayHandler(pr),
 		stack: lwip.NewLWIPStack(),
 		done:  make(chan struct{}),
 		rdBuf: make(chan []byte),

--- a/network/lwip2transport/udp_relay.go
+++ b/network/lwip2transport/udp_relay.go
@@ -1,0 +1,117 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lwip2transport
+
+import (
+	"net"
+	"net/netip"
+	"sync"
+
+	"golang.getoutline.org/sdk/network/packetrelay"
+	lwip "github.com/eycorsican/go-tun2socks/core"
+)
+
+// Compilation guard against interface implementation
+var _ lwip.UDPConnHandler = (*udpRelayHandler)(nil)
+var _ packetrelay.PacketHandler = (*udpRelayPacketForwarder)(nil)
+
+type udpRelayHandler struct {
+	mu      sync.Mutex
+	relay   packetrelay.PacketRelay
+	senders map[string]packetrelay.PacketSender
+}
+
+// newUDPRelayHandler returns a lwIP UDP connection handler natively integrated with PacketRelay.
+func newUDPRelayHandler(pr packetrelay.PacketRelay) *udpRelayHandler {
+	return &udpRelayHandler{
+		relay:   pr,
+		senders: make(map[string]packetrelay.PacketSender, 8),
+	}
+}
+
+func (h *udpRelayHandler) Connect(tunConn lwip.UDPConn, _ *net.UDPAddr) error {
+	return nil
+}
+
+// ReceiveTo relays packets from the lwIP TUN device to the proxy. It is called concurrently by lwIP.
+func (h *udpRelayHandler) ReceiveTo(tunConn lwip.UDPConn, data []byte, destAddr *net.UDPAddr) error {
+	laddr := tunConn.LocalAddr().String()
+
+	h.mu.Lock()
+	sender, ok := h.senders[laddr]
+	if !ok {
+		// Synchronize new session creation completely under the lock to prevent proxy resource leaks 
+		// when concurrent packets arrive on a new local port.
+		var err error
+		sender, err = h.newSession(tunConn)
+		if err != nil {
+			h.mu.Unlock()
+			return err
+		}
+		h.senders[laddr] = sender
+	}
+	h.mu.Unlock()
+
+	return sender.SendPacket(data, destAddr.AddrPort())
+}
+
+// newSession establishes a new packet relay association for the given UDP connection
+// and spawns the background blocking receive loop. The caller must hold h.mu.
+func (h *udpRelayHandler) newSession(conn lwip.UDPConn) (packetrelay.PacketSender, error) {
+	sender, receiver, err := h.relay.NewAssociation()
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+
+	forwarder := &udpRelayPacketForwarder{
+		conn: conn,
+		h:    h,
+	}
+
+	// Start the blocking receive loop to pull response packets using a clean Go routine
+	go func() {
+		_ = receiver.ReceivePackets(forwarder)
+		_ = h.closeSession(conn)
+	}()
+
+	return sender, nil
+}
+
+func (h *udpRelayHandler) closeSession(conn lwip.UDPConn) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	laddr := conn.LocalAddr().String()
+	err := conn.Close()
+	if sender, ok := h.senders[laddr]; ok {
+		_ = sender.Close()
+		delete(h.senders, laddr)
+	}
+	return err
+}
+
+type udpRelayPacketForwarder struct {
+	conn lwip.UDPConn
+	h    *udpRelayHandler
+}
+
+// HandlePacket relays standard response packets from the proxy back to the lwIP TUN device.
+// This avoids dynamic string-parsing overhead by using allocation-free standard Go type conversions.
+func (f *udpRelayPacketForwarder) HandlePacket(p []byte, source netip.AddrPort) error {
+	srcAddr := net.UDPAddrFromAddrPort(source)
+	_, err := f.conn.WriteFrom(p, srcAddr)
+	return err
+}

--- a/network/lwip2transport/udp_relay_test.go
+++ b/network/lwip2transport/udp_relay_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lwip2transport
+
+import (
+	"errors"
+	"net"
+	"net/netip"
+	"sync"
+	"testing"
+
+	"golang.getoutline.org/sdk/network/packetrelay"
+	"github.com/stretchr/testify/require"
+)
+
+// Make sure calling Close on a session unblocks and deletes the sender mapping concurrently.
+func TestUDPRelayCloseNoDeadlock(t *testing.T) {
+	mockRelay := &noopSingleSessionPacketRelay{
+		closeSig: make(chan struct{}),
+	}
+	h := newUDPRelayHandler(mockRelay)
+
+	localAddr := net.UDPAddrFromAddrPort(netip.MustParseAddrPort("127.0.0.1:60127"))
+	destAddr := net.UDPAddrFromAddrPort(netip.MustParseAddrPort("1.2.3.4:4321"))
+	err := h.ReceiveTo(&noopLwIPUDPConn{localAddr}, []byte{}, destAddr)
+	require.NoError(t, err)
+
+	// Ensure the session was registered
+	h.mu.Lock()
+	require.Len(t, h.senders, 1)
+	h.mu.Unlock()
+
+	// Trigger concurrent closing on the relay/sender path
+	const ConcurrentCloseCount = 50
+	errChan := make(chan error, ConcurrentCloseCount)
+	for i := 0; i < ConcurrentCloseCount; i++ {
+		go func() {
+			errChan <- h.closeSession(&noopLwIPUDPConn{localAddr})
+		}()
+	}
+
+	nNilErr := 0
+	for i := 0; i < ConcurrentCloseCount; i++ {
+		if e := <-errChan; e == nil {
+			nNilErr++
+		}
+	}
+	
+	// At least one closeSession must succeed cleanly, and the map must be empty
+	require.GreaterOrEqual(t, nNilErr, 1)
+	h.mu.Lock()
+	require.Len(t, h.senders, 0)
+	h.mu.Unlock()
+}
+
+func TestUDPRelayReceiveToNoDeadlockWhenError(t *testing.T) {
+	h := newUDPRelayHandler(errPacketRelay{})
+	localAddr := net.UDPAddrFromAddrPort(netip.MustParseAddrPort("127.0.0.1:60127"))
+	destAddr := net.UDPAddrFromAddrPort(netip.MustParseAddrPort("1.2.3.4:4321"))
+	err := h.ReceiveTo(&noopLwIPUDPConn{localAddr}, []byte{}, destAddr)
+	require.ErrorIs(t, err, errNewAssociation)
+}
+
+/********** Test Utilities **********/
+
+type noopSingleSessionPacketRelay struct {
+	mu       sync.Mutex
+	closeSig chan struct{}
+	sender   *mockRelaySender
+}
+
+func (r *noopSingleSessionPacketRelay) NewAssociation() (packetrelay.PacketSender, packetrelay.PacketReceiver, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.sender != nil {
+		return nil, nil, errors.New("only supports a single session")
+	}
+	r.sender = &mockRelaySender{relay: r}
+	return r.sender, &mockRelayReceiver{relay: r}, nil
+}
+
+type mockRelaySender struct {
+	relay *noopSingleSessionPacketRelay
+}
+
+func (s *mockRelaySender) SendPacket([]byte, netip.AddrPort) error { return nil }
+func (s *mockRelaySender) Close() error {
+	s.relay.mu.Lock()
+	defer s.relay.mu.Unlock()
+	select {
+	case <-s.relay.closeSig:
+		return packetrelay.ErrClosed
+	default:
+		close(s.relay.closeSig)
+		return nil
+	}
+}
+
+type mockRelayReceiver struct {
+	relay *noopSingleSessionPacketRelay
+}
+
+func (r *mockRelayReceiver) ReceivePackets(packetrelay.PacketHandler) error {
+	<-r.relay.closeSig
+	return nil
+}
+
+type errPacketRelay struct{}
+
+var errNewAssociation = errors.New("error in NewAssociation")
+
+func (errPacketRelay) NewAssociation() (packetrelay.PacketSender, packetrelay.PacketReceiver, error) {
+	return nil, nil, errNewAssociation
+}


### PR DESCRIPTION
This PR adds ConfigureDeviceWithRelay side-by-side native support inside LwIP, implementing allocation-free net.UDPAddrFromAddrPort address mappings and a safe UDP session creation mutex unblocking resource session leaks.

### 🔗 Dependencies
- Depends on #606