### PR TITLE
feat(network): concrete PacketListenerRelay and hot-swappable DelegatePacketRelay

### DIFF
--- a/network/packetrelay/delegate_packet_relay.go
+++ b/network/packetrelay/delegate_packet_relay.go
@@ -1,0 +1,74 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetrelay
+
+import (
+	"errors"
+	"sync/atomic"
+)
+
+// DelegatePacketRelay is a [PacketRelay] that forwards calls (like NewAssociation) to another [PacketRelay],
+// so that the caller can replace the underlying [PacketRelay] without changing the original reference.
+// To create a DelegatePacketRelay with the default PacketRelay, use [NewDelegatePacketRelay]. To change
+// the underlying [PacketRelay], use SetRelay.
+//
+// Note: After the underlying [PacketRelay] is changed, only new NewAssociation calls will be routed to the new
+// [PacketRelay]. Existing associations will not be affected.
+//
+// Multiple goroutines can simultaneously invoke methods on a DelegatePacketRelay.
+type DelegatePacketRelay interface {
+	PacketRelay
+
+	// SetRelay updates the underlying PacketRelay to `relay`; `relay` must not be nil. After this function
+	// returns, all new PacketRelay calls will be forwarded to the `relay`. Existing associations will not be affected.
+	SetRelay(relay PacketRelay) error
+}
+
+var errInvalidRelay = errors.New("the underlying relay must not be nil")
+
+// Compilation guard against interface implementation
+var _ DelegatePacketRelay = (*delegatePacketRelay)(nil)
+
+type delegatePacketRelay struct {
+	// The underlying PacketRelay when creating NewAssociation.
+	// Note that we must not use atomic.Value; otherwise TestSetRelayOfDifferentTypes will panic with
+	// "store inconsistently typed value".
+	relay atomic.Pointer[PacketRelay]
+}
+
+// NewDelegatePacketRelay creates a new [DelegatePacketRelay] that forwards calls to the `relay` [PacketRelay].
+// The `relay` must not be nil.
+func NewDelegatePacketRelay(relay PacketRelay) (DelegatePacketRelay, error) {
+	if relay == nil {
+		return nil, errInvalidRelay
+	}
+	dr := delegatePacketRelay{}
+	dr.relay.Store(&relay)
+	return &dr, nil
+}
+
+// NewAssociation implements PacketRelay.NewAssociation, and it will forward the call to the underlying PacketRelay.
+func (p *delegatePacketRelay) NewAssociation() (PacketSender, PacketReceiver, error) {
+	return (*p.relay.Load()).NewAssociation()
+}
+
+// SetRelay implements DelegatePacketRelay.SetRelay.
+func (p *delegatePacketRelay) SetRelay(relay PacketRelay) error {
+	if relay == nil {
+		return errInvalidRelay
+	}
+	p.relay.Store(&relay)
+	return nil
+}

--- a/network/packetrelay/delegate_packet_relay_test.go
+++ b/network/packetrelay/delegate_packet_relay_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetrelay
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Make sure the underlying packet relay can be initialized and updated
+func TestRelayCanBeUpdated(t *testing.T) {
+	defRelay := &sessionCountPacketRelay{}
+	newRelay := &sessionCountPacketRelay{}
+	p, err := NewDelegatePacketRelay(defRelay)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	// Initially no NewAssociation is called
+	require.Exactly(t, 0, defRelay.Count())
+	require.Exactly(t, 0, newRelay.Count())
+
+	snd, rcv, err := p.NewAssociation()
+	require.Nil(t, snd)
+	require.Nil(t, rcv)
+	require.NoError(t, err)
+
+	// defRelay.NewAssociation's count++
+	require.Exactly(t, 1, defRelay.Count())
+	require.Exactly(t, 0, newRelay.Count())
+
+	// SetRelay should not call NewAssociation
+	err = p.SetRelay(newRelay)
+	require.NoError(t, err)
+	require.Exactly(t, 1, defRelay.Count())
+	require.Exactly(t, 0, newRelay.Count())
+
+	// newRelay.NewAssociation's count += 2
+	snd, rcv, err = p.NewAssociation()
+	require.Nil(t, snd)
+	require.Nil(t, rcv)
+	require.NoError(t, err)
+
+	snd, rcv, err = p.NewAssociation()
+	require.Nil(t, snd)
+	require.Nil(t, rcv)
+	require.NoError(t, err)
+
+	require.Exactly(t, 1, defRelay.Count())
+	require.Exactly(t, 2, newRelay.Count())
+}
+
+// Make sure multiple goroutines can call NewAssociation and SetRelay concurrently
+// Need to run this test with `-race` flag
+func TestSetRelayRaceCondition(t *testing.T) {
+	const relaysCnt = 10
+	const sessionCntPerRelay = 5
+
+	var relays [relaysCnt]*sessionCountPacketRelay
+	for i := 0; i < relaysCnt; i++ {
+		relays[i] = &sessionCountPacketRelay{}
+	}
+
+	dr, err := NewDelegatePacketRelay(relays[0])
+	require.NotNil(t, dr)
+	require.NoError(t, err)
+
+	setRelayTask := &sync.WaitGroup{}
+	cancelSetRelay := &atomic.Bool{}
+	setRelayTask.Add(1)
+	go func() {
+		for i := 0; !cancelSetRelay.Load(); i = (i + 1) % relaysCnt {
+			err := dr.SetRelay(relays[i])
+			require.NoError(t, err)
+		}
+		setRelayTask.Done()
+	}()
+
+	newAssociationTask := &sync.WaitGroup{}
+	newAssociationTask.Add(1)
+	go func() {
+		for i := 0; i < relaysCnt*sessionCntPerRelay; i++ {
+			dr.NewAssociation()
+		}
+		newAssociationTask.Done()
+	}()
+
+	newAssociationTask.Wait()
+	cancelSetRelay.Store(true)
+	setRelayTask.Wait()
+
+	expectedTotal := relaysCnt * sessionCntPerRelay
+	actualTotal := 0
+	for i := 0; i < relaysCnt; i++ {
+		require.GreaterOrEqual(t, relays[i].Count(), 0)
+		actualTotal += relays[i].Count()
+	}
+	require.Equal(t, expectedTotal, actualTotal)
+}
+
+// Make sure we cannot SetRelay to nil
+func TestSetRelayWithNilValue(t *testing.T) {
+	// must not initialize with nil
+	dr, err := NewDelegatePacketRelay(nil)
+	require.Error(t, err)
+	require.Nil(t, dr)
+
+	dr, err = NewDelegatePacketRelay(&sessionCountPacketRelay{})
+	require.NoError(t, err)
+	require.NotNil(t, dr)
+
+	// must not SetRelay to nil
+	err = dr.SetRelay(nil)
+	require.Error(t, err)
+}
+
+// Make sure we can SetRelay to different types
+func TestSetRelayOfDifferentTypes(t *testing.T) {
+	defRelay := &sessionCountPacketRelay{}
+	newRelay := &noopPacketRelay{}
+
+	p, err := NewDelegatePacketRelay(defRelay)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	// SetRelay should not return error
+	err = p.SetRelay(newRelay)
+	require.NoError(t, err)
+
+	// NewAssociation should not go to defRelay
+	snd, rcv, err := p.NewAssociation()
+	require.Nil(t, snd)
+	require.Nil(t, rcv)
+	require.NoError(t, err)
+	require.Exactly(t, 0, defRelay.Count())
+}
+
+// sessionCountPacketRelay logs the count of the NewAssociation calls, and returns nil interfaces
+type sessionCountPacketRelay struct {
+	cnt atomic.Int32
+}
+
+func (sp *sessionCountPacketRelay) NewAssociation() (PacketSender, PacketReceiver, error) {
+	sp.cnt.Add(1)
+	return nil, nil, nil
+}
+
+func (sp *sessionCountPacketRelay) Count() int {
+	return int(sp.cnt.Load())
+}
+
+type noopPacketRelay struct{}
+
+func (noopPacketRelay) NewAssociation() (PacketSender, PacketReceiver, error) {
+	return nil, nil, nil
+}

--- a/network/packetrelay/packet_listener_relay.go
+++ b/network/packetrelay/packet_listener_relay.go
@@ -1,0 +1,158 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetrelay
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/netip"
+	"sync"
+
+	"golang.getoutline.org/sdk/internal/slicepool"
+	"golang.getoutline.org/sdk/transport"
+)
+
+// this was the buffer size used before, we may consider update it in the future
+const packetMaxSize = 2048
+
+// packetBufferPool is used to create buffers to read UDP response packets
+var packetBufferPool = slicepool.MakePool(packetMaxSize)
+
+// Compilation guard against interface implementation
+var _ PacketRelay = (*PacketListenerRelay)(nil)
+var _ PacketSender = (*packetListenerSender)(nil)
+var _ PacketReceiver = (*packetListenerReceiver)(nil)
+
+// PacketListenerRelay creates a new [PacketRelay] that uses the existing [transport.PacketListener] to
+// create connections to a relay.
+type PacketListenerRelay struct {
+	listener transport.PacketListener
+}
+
+// NewPacketRelayFromPacketListener creates a new [PacketRelay] that uses the existing [transport.PacketListener] to
+// create connections to a relay. You can also specify additional options.
+// This function is useful if you already have an implementation of [transport.PacketListener] and you want to use it
+// with one of the network stacks (for example, network/lwip2transport) as a UDP traffic handler.
+func NewPacketRelayFromPacketListener(pl transport.PacketListener, options ...func(*PacketListenerRelay) error) (*PacketListenerRelay, error) {
+	if pl == nil {
+		return nil, errors.New("pl must not be nil")
+	}
+	r := &PacketListenerRelay{
+		listener: pl,
+	}
+	for _, opt := range options {
+		if err := opt(r); err != nil {
+			return nil, err
+		}
+	}
+	return r, nil
+}
+
+// NewAssociation implements [PacketRelay].NewAssociation. It uses [transport.PacketListener].ListenPacket to create
+// a [net.PacketConn], and returns a [PacketSender] and [PacketReceiver] based on this [net.PacketConn].
+func (relay *PacketListenerRelay) NewAssociation() (PacketSender, PacketReceiver, error) {
+	packetConn, err := relay.listener.ListenPacket(context.Background())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sender := &packetListenerSender{
+		packetConn: packetConn,
+	}
+
+	receiver := &packetListenerReceiver{
+		packetConn: packetConn,
+	}
+
+	return sender, receiver, nil
+}
+
+type packetListenerSender struct {
+	mu     sync.Mutex // Protects closed flag
+	closed bool
+
+	packetConn net.PacketConn
+}
+
+// SendPacket implements [PacketSender].SendPacket. It simply forwards the packet to the underlying
+// [net.PacketConn].WriteTo function.
+func (s *packetListenerSender) SendPacket(p []byte, destination netip.AddrPort) error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return ErrClosed
+	}
+	packetConn := s.packetConn
+	s.mu.Unlock()
+
+	_, err := packetConn.WriteTo(p, net.UDPAddrFromAddrPort(destination))
+	return err
+}
+
+// Close implements [PacketSender].Close. It closes the underlying [net.PacketConn]. This will also
+// terminate the blocking loop in ReceivePackets because s.packetConn.ReadFrom will return an error.
+func (s *packetListenerSender) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return ErrClosed
+	}
+	s.closed = true
+	packetConn := s.packetConn
+	s.packetConn = nil
+	s.mu.Unlock()
+
+	return packetConn.Close()
+}
+
+type packetListenerReceiver struct {
+	packetConn net.PacketConn
+}
+
+// ReceivePackets implements [PacketReceiver].ReceivePackets. It blocks and passes incoming packets
+// from the relay to the handler.
+func (r *packetListenerReceiver) ReceivePackets(handler PacketHandler) error {
+	// Allocate buffer from slicepool
+	slice := packetBufferPool.LazySlice()
+	buf := slice.Acquire()
+	defer slice.Release()
+
+	for {
+		n, srcAddr, err := r.packetConn.ReadFrom(buf)
+		if err != nil {
+			if errors.Is(err, io.ErrShortBuffer) {
+				continue
+			}
+			return err
+		}
+
+		var srcPort netip.AddrPort
+		if udpAddr, ok := srcAddr.(*net.UDPAddr); ok {
+			srcPort = udpAddr.AddrPort()
+		} else {
+			var err error
+			srcPort, err = netip.ParseAddrPort(srcAddr.String())
+			if err != nil {
+				return err
+			}
+		}
+
+		if err := handler.HandlePacket(buf[:n], srcPort); err != nil {
+			return err
+		}
+	}
+}

--- a/network/packetrelay/packet_listener_relay_test.go
+++ b/network/packetrelay/packet_listener_relay_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetrelay
+
+import (
+	"testing"
+
+	"golang.getoutline.org/sdk/transport"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPacketRelayFromPacketListener(t *testing.T) {
+	pl := &transport.UDPListener{}
+
+	relay, err := NewPacketRelayFromPacketListener(pl)
+	require.NoError(t, err)
+	require.NotNil(t, relay)
+}


### PR DESCRIPTION
This PR introduces the concrete flow implementations in the standalone package: PacketListenerRelay (a single-purpose adapter over transport.PacketListener) and DelegatePacketRelay (safe hot-swappable pointer relay), complete with unit test stress coverage.

### 🔗 Dependencies
- Depends on #609