### PR TITLE
feat(x): adopt modern PacketRelay natively in outline-cli

### DIFF
--- a/x/examples/outline-cli/outline_device.go
+++ b/x/examples/outline-cli/outline_device.go
@@ -36,7 +36,7 @@ const (
 type OutlineDevice struct {
 	network.IPDevice
 	sd    transport.StreamDialer
-	pp    *outlinePacketProxy
+	pp    *outlinePacketRelay
 	svrIP net.IP
 }
 
@@ -54,10 +54,10 @@ func NewOutlineDevice(transportConfig string) (od *OutlineDevice, err error) {
 	if od.sd, err = configModule.NewStreamDialer(context.TODO(), transportConfig); err != nil {
 		return nil, fmt.Errorf("failed to create TCP dialer: %w", err)
 	}
-	if od.pp, err = newOutlinePacketProxy(transportConfig); err != nil {
+	if od.pp, err = newOutlinePacketRelay(transportConfig); err != nil {
 		return nil, fmt.Errorf("failed to create delegate UDP proxy: %w", err)
 	}
-	if od.IPDevice, err = lwip2transport.ConfigureDevice(od.sd, od.pp); err != nil {
+	if od.IPDevice, err = lwip2transport.ConfigureDeviceWithRelay(od.sd, od.pp); err != nil {
 		return nil, fmt.Errorf("failed to configure lwIP: %w", err)
 	}
 

--- a/x/examples/outline-cli/outline_packet_relay.go
+++ b/x/examples/outline-cli/outline_packet_relay.go
@@ -1,0 +1,81 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"golang.getoutline.org/sdk/dns"
+	"golang.getoutline.org/sdk/network/dnstruncate"
+	"golang.getoutline.org/sdk/network/packetrelay"
+	"golang.getoutline.org/sdk/transport"
+	"golang.getoutline.org/sdk/x/configurl"
+	"golang.getoutline.org/sdk/x/connectivity"
+)
+
+type outlinePacketRelay struct {
+	packetrelay.DelegatePacketRelay
+
+	remote, fallback packetrelay.PacketRelay
+	remotePl         transport.PacketListener
+}
+
+func newOutlinePacketRelay(transportConfig string) (opp *outlinePacketRelay, err error) {
+	opp = &outlinePacketRelay{}
+
+	if opp.remotePl, err = configurl.NewDefaultProviders().NewPacketListener(context.TODO(), transportConfig); err != nil {
+		return nil, fmt.Errorf("failed to create UDP packet listener: %w", err)
+	}
+	
+	// Create the underlying base relay
+	baseRemote, err := packetrelay.NewPacketRelayFromPacketListener(opp.remotePl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create UDP packet relay: %w", err)
+	}
+	
+	// Layer the 30s timeout explicitly
+	opp.remote, err = packetrelay.NewTimeoutPacketRelay(baseRemote, 30*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("failed to layer timeout on remote UDP relay: %w", err)
+	}
+
+	if opp.fallback, err = dnstruncate.NewPacketRelay(); err != nil {
+		return nil, fmt.Errorf("failed to create DNS truncate packet relay: %w", err)
+	}
+	if opp.DelegatePacketRelay, err = packetrelay.NewDelegatePacketRelay(opp.fallback); err != nil {
+		return nil, fmt.Errorf("failed to create delegate UDP relay: %w", err)
+	}
+
+	return
+}
+
+func (proxy *outlinePacketRelay) testConnectivityAndRefresh(resolverAddr, domain string) error {
+	dialer := transport.PacketListenerDialer{Listener: proxy.remotePl}
+	dnsResolver := dns.NewUDPResolver(dialer, resolverAddr)
+	result, err := connectivity.TestConnectivityWithResolver(context.Background(), dnsResolver, domain)
+	if err != nil {
+		logging.Info.Printf("connectivity test failed. Refresh skipped. Error: %v\n", err)
+		return err
+	}
+	if result != nil {
+		logging.Info.Println("remote server cannot handle UDP traffic, switch to DNS truncate mode.")
+		return proxy.SetRelay(proxy.fallback)
+	} else {
+		logging.Info.Println("remote server supports UDP, we will delegate all UDP packets to it")
+		return proxy.SetRelay(proxy.remote)
+	}
+}

--- a/x/go.mod
+++ b/x/go.mod
@@ -138,3 +138,5 @@ require (
 )
 
 tool honnef.co/go/tools/cmd/staticcheck
+
+replace golang.getoutline.org/sdk => ../


### PR DESCRIPTION
This PR migrates the x/examples/outline-cli tool to natively wire the new outlinePacketRelay flow and LwIP's ConfigureDeviceWithRelay directly. Stages x/go.mod local replace workaround for cross-module build resolution.

### 🔗 Dependencies
- Depends on #616