### PR TITLE
docs(cli): document Go proxy fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,8 +275,8 @@ Downloaded Speed: 5.61 MB/s
 
 ## Resolving Access Issues
 
-The Outline SDK go packages are accessed through the vanity Go URL `golang.getoutline.org`. If you experience [issues](https://github.com/OutlineFoundation/outline-sdk/issues/571) accessing this URL on your local network you can modify the commands to access the code through `proxy.golang.org`.
+The Outline SDK Go packages are accessed through the vanity Go URL `golang.getoutline.org`. If you experience [issues](https://github.com/OutlineFoundation/outline-sdk/issues/571) accessing this URL on your local network, you can modify the commands to access the code through `proxy.golang.org`.
 
 ```console
-sudo env GOPROXY=https://proxy.golang.org go run golang.getoutline.org/sdk/x/examples/outline-cli@latest
+sudo env GOPROXY=https://proxy.golang.org go run golang.getoutline.org/sdk/x/examples/outline-cli@latest -transport "ss://<outline-server-access-key>"
 ```

--- a/x/examples/outline-cli/README.md
+++ b/x/examples/outline-cli/README.md
@@ -10,6 +10,12 @@ go run golang.getoutline.org/sdk/x/examples/outline-cli@latest -transport "ss://
 
 - `-transport` : the Outline server access key from the service provider, it should start with "ss://"
 
+If your network cannot reach `golang.getoutline.org`, prefix the command with the public Go module proxy:
+
+```
+sudo env GOPROXY=https://proxy.golang.org go run golang.getoutline.org/sdk/x/examples/outline-cli@latest -transport "ss://<outline-server-access-key>"
+```
+
 ### Build
 
 You can use the following command to build the CLI.


### PR DESCRIPTION
## Summary
- add the `GOPROXY=https://proxy.golang.org` fallback to the Outline CLI README
- include the required `-transport` argument in the root README fallback command

Fixes #571

## Validation
- `git diff --check`
- `go run golang.getoutline.org/sdk/x/examples/outline-cli@latest --help`
- `env GOPROXY=https://proxy.golang.org go run golang.getoutline.org/sdk/x/examples/outline-cli@latest --help`

If this PR is squashed or reworked, please preserve author attribution or include: Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>