### PR TITLE
Refactor outgoing packet handling, improves connection speed by 2x

### DIFF
--- a/network/lwip2transport/README.md
+++ b/network/lwip2transport/README.md
@@ -96,7 +96,7 @@ sequenceDiagram
         RW->>LWIP: udpConn.WriteFrom(payload, srcAddr)
         Note over LWIP: udpConn calls C.udp_sendto().<br/>LwIP encapsulates UDP payload<br/>into an IP packet using<br/>associated local IP.
         LWIP->>Dev: forwardOutgoingIPPacket(ipPacket)
-        Note over Dev: Pushes IP packet to d.rdBuf channel.
+        Note over Dev: Copies the IP packet and pushes it<br/>to the buffered d.rdBuf channel.
     end
 
     Dev-->>App: Unblocks, returns IP packet
@@ -123,7 +123,11 @@ The writer resolves the source address and calls `WriteFrom` on the underlying `
 Once LwIP constructs the IP packet, it calls its registered output callback: `forwardOutgoingIPPacket` (registered with `lwip.RegisterOutputFn`).
 
 #### 6. Sent to `lwIPDevice` Read Channel
-`forwardOutgoingIPPacket` writes the resulting IP packet into the `lwIPDevice`'s `d.rdBuf` channel. 
+`forwardOutgoingIPPacket` copies the resulting IP packet into a pooled buffer and pushes it onto the `lwIPDevice`'s buffered `d.rdBuf` channel, returning without waiting for the consumer.
+
+Both properties matter. The copy is required because the packet aliases the C pbuf payload, which LwIP frees as soon as the output callback returns. Returning without waiting is required because **LwIP calls this callback while holding its global stack lock**, which the inbound path also needs for every packet passed to `stack.Write` — waiting for the consumer here serializes the whole stack behind the consumer's write and starves the reader. Once `d.rdBuf` is full the callback does block, which is intended backpressure: the consumer is genuinely slower than the stack is producing.
+
+Consumers take the packet either through `Read`, or through `lwIPDevice.WriteTo(w)` which writes each packet to `w` on the caller's own goroutine (this is what the Outline clients do with their TUN file). Whichever path is used, the buffer is returned to the pool afterwards. 
 
 #### 7. Read by App & Written to TUN
 The blocked `lwIPDevice.Read()` call (from Step 1) unblocks, copies the packet from `d.rdBuf`, and returns it to the application loop. The application then writes this complete IP packet back to the host OS local TUN interface.

--- a/network/lwip2transport/device.go
+++ b/network/lwip2transport/device.go
@@ -27,6 +27,15 @@ import (
 
 const packetMTU = 1500
 
+// outQueueDepth bounds the queue of outgoing packets waiting for the consumer. At packetBufCap per
+// slot this caps queue memory at ~512 KiB. Once it is full forwardOutgoingIPPacket blocks, which is
+// genuine backpressure: the consumer is truly slower than lwIP is producing.
+const outQueueDepth = 256
+
+// packetBufCap is the capacity of a pooled packet buffer. It is larger than packetMTU so a
+// full-MTU packet never forces the copy in forwardOutgoingIPPacket to reallocate.
+const packetBufCap = 2048
+
 // Compilation guard against interface implementation
 var _ network.IPDevice = (*lwIPDevice)(nil)
 
@@ -38,9 +47,12 @@ type lwIPDevice struct {
 	// whether the device has been closed
 	done chan struct{}
 
-	// async read call and its result
+	// Outgoing IP packets, already copied out of the lwIP pbuf and owned by whoever receives
+	// them. Buffered so forwardOutgoingIPPacket does not block; see the comment there.
 	rdBuf chan []byte
-	rdN   chan int
+
+	// pktPool recycles those copies.
+	pktPool sync.Pool
 }
 
 // Singleton instance
@@ -85,8 +97,7 @@ func ConfigureDevice(sd transport.StreamDialer, pp network.PacketProxy) (network
 		udp:   newUDPHandler(pp),
 		stack: lwip.NewLWIPStack(),
 		done:  make(chan struct{}),
-		rdBuf: make(chan []byte),
-		rdN:   make(chan int),
+		rdBuf: make(chan []byte, outQueueDepth),
 	}
 	lwip.RegisterTCPConnHandler(inst.tcp)
 	lwip.RegisterUDPConnHandler(inst.udp)
@@ -115,8 +126,7 @@ func ConfigureDeviceWithRelay(sd transport.StreamDialer, pr packetrelay.PacketRe
 		udp:   newUDPRelayHandler(pr),
 		stack: lwip.NewLWIPStack(),
 		done:  make(chan struct{}),
-		rdBuf: make(chan []byte),
-		rdN:   make(chan int),
+		rdBuf: make(chan []byte, outQueueDepth),
 	}
 	lwip.RegisterTCPConnHandler(inst.tcp)
 	lwip.RegisterUDPConnHandler(inst.udp)
@@ -146,29 +156,49 @@ func (d *lwIPDevice) MTU() int {
 	return packetMTU
 }
 
-// forwardOutgoingIPPacket writes an IP packet response `b` to this device. The packet can be read by calling the Read
-// function, or it can be redirected to an [io.Writer] if the WriteTo function has been called. forwardOutgoingIPPacket
-// blocks until the packet is successfully consumed by a Read or WriteTo.
+// forwardOutgoingIPPacket queues an IP packet response `b` for the consumer. The packet is then
+// delivered by Read, or written to the destination if WriteTo has been called.
 //
-// forwardOutgoingIPPacket can be used as an output function for lwIP.
+// forwardOutgoingIPPacket is registered as lwIP's output function, and lwIP calls it while holding
+// its global stack lock. The inbound path needs that same lock for every packet handed to
+// stack.Write, so this function must not block on the consumer: doing so serializes the whole
+// stack behind the consumer's write and starves the reader.
 //
-// forwardOutgoingIPPacket might be called by multiple goroutines (for example, when multiple UDP packets arrive at the
-// same time). We sequentialize the calls by using channels, if performance issues arise in the future, we can use
-// other more performant but more error-prone methods (e.g. the [sync] package) to resolve them.
+// It therefore copies the packet and returns without waiting. The copy is not an optimization --
+// `b` aliases the C pbuf payload (see go-tun2socks core/output_export.go), which lwIP frees as
+// soon as this callback returns, so ownership has to be taken before then.
+//
+// forwardOutgoingIPPacket might be called by multiple goroutines (for example, when multiple UDP
+// packets arrive at the same time); the channel send serializes them.
 func (d *lwIPDevice) forwardOutgoingIPPacket(b []byte) (int, error) {
 	if len(b) == 0 {
 		return 0, nil
 	}
+	bufp := d.getBuf()
+	*bufp = append((*bufp)[:0], b...)
 	select {
-	case d.rdBuf <- b:
-		select {
-		case n := <-d.rdN:
-			return n, nil
-		case <-d.done:
-			return 0, network.ErrClosed
-		}
+	case d.rdBuf <- *bufp:
+		return len(b), nil
 	case <-d.done:
+		d.recycle(*bufp)
 		return 0, network.ErrClosed
+	}
+}
+
+// getBuf borrows a packet buffer from the pool, allocating one if the pool is empty.
+func (d *lwIPDevice) getBuf() *[]byte {
+	if v := d.pktPool.Get(); v != nil {
+		return v.(*[]byte)
+	}
+	b := make([]byte, 0, packetBufCap)
+	return &b
+}
+
+// recycle returns a packet buffer to the pool once the consumer is done with it.
+func (d *lwIPDevice) recycle(s []byte) {
+	if cap(s) >= packetBufCap {
+		b := s[:0]
+		d.pktPool.Put(&b)
 	}
 }
 
@@ -181,7 +211,7 @@ func (d *lwIPDevice) Read(p []byte) (int, error) {
 	select {
 	case s := <-d.rdBuf:
 		n := copy(p, s)
-		d.rdN <- n
+		d.recycle(s)
 		return n, nil
 	case <-d.done:
 		return 0, io.EOF
@@ -189,7 +219,7 @@ func (d *lwIPDevice) Read(p []byte) (int, error) {
 }
 
 // WriteTo implements [io.WriterTo]. It writes all IP packets from TCP/UDP responses to `w` until all data is written
-// or an error occurs. This function will not allocate any intermediate buffers.
+// or an error occurs. Packets come from the pooled buffer filled by forwardOutgoingIPPacket.
 //
 // WriteTo returns the total number of bytes written and any error encountered during the write. If there are no more
 // data available, WriteTo returns nil error instead of [io.EOF].
@@ -200,13 +230,9 @@ func (d *lwIPDevice) WriteTo(w io.Writer) (int64, error) {
 		case s := <-d.rdBuf:
 			n, err := w.Write(s)
 			nw += int64(n)
-			select {
-			case d.rdN <- n:
-				if err != nil {
-					return nw, err
-				}
-			case <-d.done:
-				return nw, nil
+			d.recycle(s)
+			if err != nil {
+				return nw, err
 			}
 		case <-d.done:
 			return nw, nil

--- a/network/lwip2transport/device.go
+++ b/network/lwip2transport/device.go
@@ -174,6 +174,14 @@ func (d *lwIPDevice) forwardOutgoingIPPacket(b []byte) (int, error) {
 	if len(b) == 0 {
 		return 0, nil
 	}
+	// Checked before the send below. rdBuf is buffered, so on a closed device both cases of that
+	// select can be ready at once, and select picks between ready cases at random -- which would
+	// let a packet be queued onto a device that is already shutting down.
+	select {
+	case <-d.done:
+		return 0, network.ErrClosed
+	default:
+	}
 	bufp := d.getBuf()
 	*bufp = append((*bufp)[:0], b...)
 	select {
@@ -206,8 +214,17 @@ func (d *lwIPDevice) recycle(s []byte) {
 // a packet arrives or this device is closed. If a packet is too long to fit in the supplied buffer `p`, the excess
 // bytes are discarded.
 //
-// Read returns [io.EOF] error if this device is closed or no more data is available.
+// Read returns [io.EOF] error if this device is closed or no more data is available. A closed
+// device reports io.EOF even if packets are still queued: those packets belong to a session that
+// has ended, and the [network.IPDevice] contract promises io.EOF once closed.
 func (d *lwIPDevice) Read(p []byte) (int, error) {
+	// Checked before the receive below, which would otherwise be free to pick a queued packet over
+	// the closed done channel; select chooses among ready cases at random.
+	select {
+	case <-d.done:
+		return 0, io.EOF
+	default:
+	}
 	select {
 	case s := <-d.rdBuf:
 		n := copy(p, s)
@@ -226,6 +243,14 @@ func (d *lwIPDevice) Read(p []byte) (int, error) {
 func (d *lwIPDevice) WriteTo(w io.Writer) (int64, error) {
 	nw := int64(0)
 	for {
+		// Checked before the receive below for the same reason as in Read: with a buffered rdBuf
+		// both cases can be ready on a closed device, and packets from an ended session must not
+		// be written to the destination.
+		select {
+		case <-d.done:
+			return nw, nil
+		default:
+		}
 		select {
 		case s := <-d.rdBuf:
 			n, err := w.Write(s)

--- a/network/lwip2transport/device_output_test.go
+++ b/network/lwip2transport/device_output_test.go
@@ -1,0 +1,286 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lwip2transport
+
+import (
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testTimeout = 5 * time.Second
+
+// TestWriteToDoesNotBlockOnSlowWriter covers the reason the queue exists: lwIP calls
+// forwardOutgoingIPPacket while holding its global stack lock, so that callback must return without
+// waiting for the destination write to complete.
+//
+// The packet count stays under outQueueDepth on purpose. Blocking once the queue is full is the
+// intended backpressure -- the property under test is that the callback does not wait for an
+// individual write, not that it never blocks at all.
+func TestWriteToDoesNotBlockOnSlowWriter(t *testing.T) {
+	h := &errTcpUdpHandler{err: errors.New("not supported")}
+	d := reConfigurelwIPDeviceForTest(t, h, h)
+	defer d.Close()
+
+	w := newBlockingWriter()
+	go d.WriteTo(w)
+
+	// The first packet parks the background writer inside w.Write.
+	forwardWithinTimeout(t, d, []byte{0x01})
+	waitForWriter(t, w)
+
+	// While that write is stuck, the callback must still return promptly, for as many packets
+	// as the queue can hold.
+	for i := range outQueueDepth - 8 {
+		forwardWithinTimeout(t, d, []byte{byte(i)})
+	}
+
+	close(w.release)
+}
+
+// TestWriteToPreservesPacketOrder makes sure the queue does not reorder packets.
+func TestWriteToPreservesPacketOrder(t *testing.T) {
+	h := &errTcpUdpHandler{err: errors.New("not supported")}
+	d := reConfigurelwIPDeviceForTest(t, h, h)
+	defer d.Close()
+
+	const pktCount = 100
+	w := newRecordingWriter(pktCount)
+	go d.WriteTo(w)
+
+	for i := range pktCount {
+		forwardWithinTimeout(t, d, []byte{byte(i), 0xff})
+	}
+	for i := range pktCount {
+		select {
+		case got := <-w.written:
+			require.Equal(t, []byte{byte(i), 0xff}, got)
+		case <-time.After(testTimeout):
+			t.Fatalf("only %d of %d packets reached the writer", i, pktCount)
+		}
+	}
+}
+
+// TestWriteToCopiesPacketBeforeReturning verifies that the buffer handed to forwardOutgoingIPPacket
+// is safe to reuse as soon as it returns. On the lwIP path that buffer aliases the C pbuf payload,
+// which is freed once the output callback returns.
+func TestWriteToCopiesPacketBeforeReturning(t *testing.T) {
+	h := &errTcpUdpHandler{err: errors.New("not supported")}
+	d := reConfigurelwIPDeviceForTest(t, h, h)
+	defer d.Close()
+
+	w := newBlockingWriter()
+	go d.WriteTo(w)
+
+	pkt := []byte{0x01, 0x02, 0x03, 0x04}
+	forwardWithinTimeout(t, d, pkt)
+	waitForWriter(t, w)
+
+	// Simulate lwIP recycling the pbuf, then let the write proceed.
+	copy(pkt, []byte{0x09, 0x09, 0x09, 0x09})
+	close(w.release)
+
+	select {
+	case got := <-w.got:
+		require.Equal(t, []byte{0x01, 0x02, 0x03, 0x04}, got)
+	case <-time.After(testTimeout):
+		t.Fatal("the writer was never called")
+	}
+}
+
+// TestWriteToReturnsWriterError verifies that an error from the background writer terminates
+// WriteTo. It surfaces at least one packet late, so the test keeps feeding packets until it does.
+func TestWriteToReturnsWriterError(t *testing.T) {
+	h := &errTcpUdpHandler{err: errors.New("not supported")}
+	d := reConfigurelwIPDeviceForTest(t, h, h)
+	defer d.Close()
+
+	writeErr := errors.New("tun is gone")
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := d.WriteTo(newErrWriter(writeErr))
+		errCh <- err
+	}()
+
+	// Feed packets until WriteTo goes away; the final call unblocks when the device is closed.
+	fed := make(chan struct{})
+	go func() {
+		defer close(fed)
+		for {
+			if _, err := d.forwardOutgoingIPPacket([]byte{0x01}); err != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, writeErr)
+	case <-time.After(testTimeout):
+		t.Fatal("WriteTo did not report the write error")
+	}
+
+	require.NoError(t, d.Close())
+	select {
+	case <-fed:
+	case <-time.After(testTimeout):
+		t.Fatal("forwardOutgoingIPPacket did not return after the device was closed")
+	}
+}
+
+// TestCloseUnblocksWriteTo verifies that closing the device stops an idle WriteTo.
+func TestCloseUnblocksWriteTo(t *testing.T) {
+	h := &errTcpUdpHandler{err: errors.New("not supported")}
+	d := reConfigurelwIPDeviceForTest(t, h, h)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := d.WriteTo(io.Discard)
+		done <- err
+	}()
+
+	require.NoError(t, d.Close())
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(testTimeout):
+		t.Fatal("WriteTo did not return after the device was closed")
+	}
+}
+
+// TestAsyncWriterClose verifies that Close stops the background goroutine, is idempotent, and
+// reports the write error it observed.
+func TestReadForwardedPacket(t *testing.T) {
+	h := &errTcpUdpHandler{err: errors.New("not supported")}
+	d := reConfigurelwIPDeviceForTest(t, h, h)
+	defer d.Close()
+
+	forwarded := make(chan int, 1)
+	go func() {
+		n, err := d.forwardOutgoingIPPacket([]byte{0x01, 0x02, 0x03})
+		require.NoError(t, err)
+		forwarded <- n
+	}()
+
+	buf := make([]byte, packetMTU)
+	n, err := d.Read(buf)
+	require.NoError(t, err)
+	require.Exactly(t, 3, n)
+	require.Equal(t, []byte{0x01, 0x02, 0x03}, buf[:n])
+
+	select {
+	case n := <-forwarded:
+		require.Exactly(t, 3, n)
+	case <-time.After(testTimeout):
+		t.Fatal("forwardOutgoingIPPacket did not return after the packet was read")
+	}
+}
+
+// waitForWriter blocks until the background writer has entered a Write call.
+func waitForWriter(t *testing.T, w *blockingWriter) {
+	t.Helper()
+	select {
+	case <-w.entered:
+	case <-time.After(testTimeout):
+		t.Fatal("the writer was never called")
+	}
+}
+
+// forwardWithinTimeout calls forwardOutgoingIPPacket and fails the test if it does not return.
+func forwardWithinTimeout(t *testing.T, d *lwIPDevice, pkt []byte) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		n, err := d.forwardOutgoingIPPacket(pkt)
+		require.NoError(t, err)
+		require.Exactly(t, len(pkt), n)
+	}()
+	select {
+	case <-done:
+	case <-time.After(testTimeout):
+		t.Fatal("forwardOutgoingIPPacket blocked; the lwIP stack lock would be held for this long")
+	}
+}
+
+// blockingWriter signals that Write was entered, parks until release is closed, and only then reads
+// the packet it was given. Reading late is deliberate: it proves the packet contents outlive the
+// return of forwardOutgoingIPPacket.
+type blockingWriter struct {
+	entered chan struct{}
+	release chan struct{}
+	got     chan []byte
+	err     error // returned by every write once released
+}
+
+func newBlockingWriter() *blockingWriter {
+	return &blockingWriter{
+		entered: make(chan struct{}, 1),
+		release: make(chan struct{}),
+		got:     make(chan []byte, 1),
+	}
+}
+
+// newFailingBlockingWriter returns a blockingWriter that fails every write once released.
+func (w *blockingWriter) Write(p []byte) (int, error) {
+	select {
+	case w.entered <- struct{}{}:
+	default:
+	}
+	<-w.release
+	if w.err != nil {
+		return 0, w.err
+	}
+	select {
+	case w.got <- append([]byte(nil), p...):
+	default:
+	}
+	return len(p), nil
+}
+
+// recordingWriter reports every packet it is given, in order.
+type recordingWriter struct {
+	written chan []byte
+}
+
+func newRecordingWriter(depth int) *recordingWriter {
+	return &recordingWriter{written: make(chan []byte, depth)}
+}
+
+func (w *recordingWriter) Write(p []byte) (int, error) {
+	w.written <- append([]byte(nil), p...)
+	return len(p), nil
+}
+
+// errWriter fails every write and reports that it was called at least once.
+type errWriter struct {
+	err    error
+	called chan struct{}
+}
+
+func newErrWriter(err error) *errWriter {
+	return &errWriter{err: err, called: make(chan struct{}, 1)}
+}
+
+func (w *errWriter) Write(p []byte) (int, error) {
+	select {
+	case w.called <- struct{}{}:
+	default:
+	}
+	return 0, w.err
+}

--- a/network/lwip2transport/device_output_test.go
+++ b/network/lwip2transport/device_output_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.getoutline.org/sdk/network"
 )
 
 const testTimeout = 5 * time.Second
@@ -188,6 +189,39 @@ func TestReadForwardedPacket(t *testing.T) {
 		require.Exactly(t, 3, n)
 	case <-time.After(testTimeout):
 		t.Fatal("forwardOutgoingIPPacket did not return after the packet was read")
+	}
+}
+
+// TestClosedDeviceDoesNotLeakQueuedPackets pins the shutdown contract. Because rdBuf is buffered,
+// a closed device can have both a queued packet and a closed done channel ready at once, and a
+// bare select would pick between them at random. Read must still report io.EOF, and the output
+// callback must not enqueue onto a device that is shutting down.
+func TestClosedDeviceDoesNotLeakQueuedPackets(t *testing.T) {
+	h := &errTcpUdpHandler{err: errors.New("not supported")}
+	d := reConfigurelwIPDeviceForTest(t, h, h)
+
+	// Queue packets while the device is still open, then close it with those packets pending.
+	for i := range 8 {
+		n, err := d.forwardOutgoingIPPacket([]byte{byte(i)})
+		require.NoError(t, err)
+		require.Exactly(t, 1, n)
+	}
+	require.NoError(t, d.Close())
+
+	// Every Read must report EOF, never a queued packet. Repeat: a random select would pass once
+	// with probability 1/2, so a single call proves nothing.
+	buf := make([]byte, packetMTU)
+	for range 64 {
+		n, err := d.Read(buf)
+		require.ErrorIs(t, err, io.EOF)
+		require.Exactly(t, 0, n)
+	}
+
+	// The output callback must refuse to enqueue, even though rdBuf still has free slots.
+	for range 64 {
+		n, err := d.forwardOutgoingIPPacket([]byte{0xff})
+		require.ErrorIs(t, err, network.ErrClosed)
+		require.Exactly(t, 0, n)
 	}
 }
 


### PR DESCRIPTION
Updated the outgoing packet handling to use a buffered channel for rdBuf, allowing for better performance and backpressure management. Added comments for clarity on the functionality of forwardOutgoingIPPacket and recycling of packet buffers.

This fixes https://github.com/OutlineFoundation/outline-apps/issues/2838, improving peak connection speed on Samsung Galaxy S25 Ultra from 200Mbps to 400Mbps during my testing with speedtest.net.