### PR TITLE
fix(lwip2transport): bound half-closed TCP relays

### DIFF
--- a/network/lwip2transport/tcp.go
+++ b/network/lwip2transport/tcp.go
@@ -18,10 +18,14 @@ import (
 	"context"
 	"io"
 	"net"
+	"time"
 
-	"golang.getoutline.org/sdk/transport"
 	lwip "github.com/eycorsican/go-tun2socks/core"
+	"golang.getoutline.org/sdk/transport"
 )
+
+// halfCloseTimeout limits how long a peer can leave a relay half-closed.
+const halfCloseTimeout = 30 * time.Second
 
 // Compilation guard against interface implementation
 var _ lwip.TCPConnHandler = (*tcpHandler)(nil)
@@ -65,18 +69,28 @@ func copyOneWay(leftConn, rightConn transport.StreamConn) (int64, error) {
 // Relay allows for half-closed connections: if one side is done writing, it can
 // still read all remaining data from its peer.
 func relay(leftConn, rightConn transport.StreamConn) (int64, int64, error) {
+	return relayWithHalfCloseTimeout(leftConn, rightConn, halfCloseTimeout)
+}
+
+func relayWithHalfCloseTimeout(leftConn, rightConn transport.StreamConn, timeout time.Duration) (int64, int64, error) {
 	type res struct {
 		N   int64
 		Err error
 	}
 	ch := make(chan res)
+	defer leftConn.Close()
+	defer rightConn.Close()
 
 	go func() {
 		n, err := copyOneWay(rightConn, leftConn)
+		// Bound the remaining right-to-left copy if the peer never sends FIN.
+		rightConn.SetReadDeadline(time.Now().Add(timeout))
 		ch <- res{n, err}
 	}()
 
 	n, err := copyOneWay(leftConn, rightConn)
+	// Bound the remaining left-to-right copy if the peer never sends FIN.
+	leftConn.SetReadDeadline(time.Now().Add(timeout))
 	rs := <-ch
 
 	if err == nil {

--- a/network/lwip2transport/tcp_test.go
+++ b/network/lwip2transport/tcp_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lwip2transport
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type testStreamConn struct {
+	net.Conn
+	closeCount atomic.Int32
+}
+
+func (c *testStreamConn) CloseRead() error  { return nil }
+func (c *testStreamConn) CloseWrite() error { return nil }
+
+func (c *testStreamConn) Close() error {
+	c.closeCount.Add(1)
+	return c.Conn.Close()
+}
+
+func TestRelayClosesStalledHalfClosedConnections(t *testing.T) {
+	left, leftPeer := net.Pipe()
+	leftPeer.Close()
+	right, rightPeer := net.Pipe()
+	defer rightPeer.Close()
+	leftConn := &testStreamConn{Conn: left}
+	rightConn := &testStreamConn{Conn: right}
+	start := time.Now()
+
+	relayWithHalfCloseTimeout(leftConn, rightConn, 10*time.Millisecond)
+
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("relay took %v after a stalled half-close", elapsed)
+	}
+	if got := leftConn.closeCount.Load(); got != 1 {
+		t.Errorf("left connection close count = %d, want 1", got)
+	}
+	if got := rightConn.closeCount.Load(); got != 1 {
+		t.Errorf("right connection close count = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
## Summary

- bound TCP relay half-close handling to 30 seconds
- fully close both relay connections once copying finishes
- add a regression test for a peer that never completes its half-close

## Problem

When one copy direction reaches EOF, `copyOneWay` half-closes the destination, but `relay` waits indefinitely for the opposite direction. If that peer never sends FIN, the application-owned proxy socket can remain in `FIN_WAIT_2` indefinitely.

On macOS this reproduced as more than 16,000 `FIN_WAIT_2` sockets to one Outline server, exhausting the 16,384-port ephemeral range and causing unrelated connections to fail with `EADDRNOTAVAIL`.

## Approach

After either copy direction completes, set a read deadline on the connection used by the remaining direction. This retains half-close behavior for responses that finish within 30 seconds, uses the existing relay goroutine structure, and guarantees both connections are fully closed afterward.

## Verification

- `go test -race ./...`
- `go tool staticcheck ./network/lwip2transport`