### PR TITLE
feat(fetch): add QUIC version selection

### DIFF
--- a/x/tools/fetch/README.md
+++ b/x/tools/fetch/README.md
@@ -2,16 +2,16 @@
 
 This app illustrates how to use different transports to fetch a URL in Go.
 
-When using HTTP/3, `-quic-versions` selects the ordered QUIC versions offered by
-QUIC-Go. For example, force RFC 9369 QUIC v2 with:
+When using HTTP/3, `-quic-versions` selects the ordered QUIC versions. For
+example, force RFC 9369 QUIC v2 with:
 
 ```console
-fetch -proto h3 -quic-versions v2 -method HEAD -v https://example.com/
+fetch -proto h3 -quic-versions 2 -method HEAD -v https://example.com/
 ```
 
 The tool logs the negotiated QUIC version and wire codepoint after a successful
-HTTP/3 request. Use `v1,v2` (the default) for QUIC-Go's normal preference order,
-or `v2,v1` to prefer v2 while allowing fallback through version negotiation.
+HTTP/3 request. Use `1,2` (the default) to prefer v1, or `2,1` to prefer v2
+while allowing fallback through version negotiation.
 
 Direct fetch:
 

--- a/x/tools/fetch/README.md
+++ b/x/tools/fetch/README.md
@@ -2,6 +2,17 @@
 
 This app illustrates how to use different transports to fetch a URL in Go.
 
+When using HTTP/3, `-quic-versions` selects the ordered QUIC versions offered by
+QUIC-Go. For example, force RFC 9369 QUIC v2 with:
+
+```console
+fetch -proto h3 -quic-versions v2 -method HEAD -v https://example.com/
+```
+
+The tool logs the negotiated QUIC version and wire codepoint after a successful
+HTTP/3 request. Use `v1,v2` (the default) for QUIC-Go's normal preference order,
+or `v2,v1` to prefer v2 while allowing fallback through version negotiation.
+
 Direct fetch:
 
 ```sh

--- a/x/tools/fetch/main.go
+++ b/x/tools/fetch/main.go
@@ -40,7 +40,7 @@ import (
 
 type stringArrayFlagValue []string
 
-const defaultQUICVersions = "v1,v2"
+const defaultQUICVersions = "1,2"
 
 func (v *stringArrayFlagValue) String() string {
 	return fmt.Sprint(*v)
@@ -56,13 +56,13 @@ func parseQUICVersions(value string) ([]quic.Version, error) {
 	seen := make(map[quic.Version]bool)
 	for _, name := range strings.Split(value, ",") {
 		var version quic.Version
-		switch strings.ToLower(strings.TrimSpace(name)) {
-		case "v1", "1", "0x00000001":
+		switch strings.TrimSpace(name) {
+		case "1":
 			version = quic.Version1
-		case "v2", "2", "0x6b3343cf":
+		case "2":
 			version = quic.Version2
 		default:
-			return nil, fmt.Errorf("unknown QUIC version %q (want v1 or v2)", name)
+			return nil, fmt.Errorf("unknown QUIC version %q (want 1 or 2)", name)
 		}
 		if seen[version] {
 			return nil, fmt.Errorf("duplicate QUIC version %q", name)
@@ -104,7 +104,7 @@ func main() {
 	transportFlag := flag.String("transport", "", "Transport config")
 
 	protoFlag := flag.String("proto", "h1", "HTTP version to use (h1, h2, h3)")
-	quicVersionsFlag := flag.String("quic-versions", defaultQUICVersions, "Ordered QUIC versions for h3 (v1, v2, or a comma-separated list)")
+	quicVersionsFlag := flag.String("quic-versions", defaultQUICVersions, "Ordered QUIC versions for h3 (1, 2, or a comma-separated list)")
 	methodFlag := flag.String("method", "GET", "The HTTP method to use")
 	var headersFlag stringArrayFlagValue
 	flag.Var(&headersFlag, "H", "Raw HTTP Header line to add. It must not end in \\r\\n")

--- a/x/tools/fetch/main.go
+++ b/x/tools/fetch/main.go
@@ -31,14 +31,16 @@ import (
 	"strings"
 	"time"
 
-	"golang.getoutline.org/sdk/x/configurl"
 	"github.com/lmittmann/tint"
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
+	"golang.getoutline.org/sdk/x/configurl"
 	"golang.org/x/term"
 )
 
 type stringArrayFlagValue []string
+
+const defaultQUICVersions = "v1,v2"
 
 func (v *stringArrayFlagValue) String() string {
 	return fmt.Sprint(*v)
@@ -47,6 +49,28 @@ func (v *stringArrayFlagValue) String() string {
 func (v *stringArrayFlagValue) Set(value string) error {
 	*v = append(*v, value)
 	return nil
+}
+
+func parseQUICVersions(value string) ([]quic.Version, error) {
+	var versions []quic.Version
+	seen := make(map[quic.Version]bool)
+	for _, name := range strings.Split(value, ",") {
+		var version quic.Version
+		switch strings.ToLower(strings.TrimSpace(name)) {
+		case "v1", "1", "0x00000001":
+			version = quic.Version1
+		case "v2", "2", "0x6b3343cf":
+			version = quic.Version2
+		default:
+			return nil, fmt.Errorf("unknown QUIC version %q (want v1 or v2)", name)
+		}
+		if seen[version] {
+			return nil, fmt.Errorf("duplicate QUIC version %q", name)
+		}
+		seen[version] = true
+		versions = append(versions, version)
+	}
+	return versions, nil
 }
 
 func init() {
@@ -80,6 +104,7 @@ func main() {
 	transportFlag := flag.String("transport", "", "Transport config")
 
 	protoFlag := flag.String("proto", "h1", "HTTP version to use (h1, h2, h3)")
+	quicVersionsFlag := flag.String("quic-versions", defaultQUICVersions, "Ordered QUIC versions for h3 (v1, v2, or a comma-separated list)")
 	methodFlag := flag.String("method", "GET", "The HTTP method to use")
 	var headersFlag stringArrayFlagValue
 	flag.Var(&headersFlag, "H", "Raw HTTP Header line to add. It must not end in \\r\\n")
@@ -113,6 +138,10 @@ func main() {
 		flag.Usage()
 		os.Exit(1)
 	}
+	if *protoFlag != "h3" && *quicVersionsFlag != defaultQUICVersions {
+		slog.Error("-quic-versions requires -proto h3")
+		os.Exit(1)
+	}
 
 	httpClient := &http.Client{
 		Timeout: time.Duration(*timeoutSecFlag) * time.Second,
@@ -141,6 +170,7 @@ func main() {
 		defer f.Close()
 		tlsConfig.KeyLogWriter = f
 	}
+	var quicConn quic.EarlyConnection
 	providers := configurl.NewDefaultProviders()
 	if *protoFlag == "h1" || *protoFlag == "h2" {
 		dialer, err := providers.NewStreamDialer(context.Background(), *transportFlag)
@@ -174,6 +204,11 @@ func main() {
 			}
 		}
 	} else if *protoFlag == "h3" {
+		quicVersions, err := parseQUICVersions(*quicVersionsFlag)
+		if err != nil {
+			slog.Error("Invalid QUIC versions", "error", err)
+			os.Exit(1)
+		}
 		listener, err := providers.NewPacketListener(context.Background(), *transportFlag)
 		if err != nil {
 			slog.Error("Could not create listener", "error", err)
@@ -199,7 +234,14 @@ func main() {
 				if err != nil {
 					return nil, err
 				}
-				return quicTransport.DialEarly(ctx, udpAddr, tlsConf, quicConf)
+				quicConf = quicConf.Clone()
+				quicConf.Versions = quicVersions
+				conn, err := quicTransport.DialEarly(ctx, udpAddr, tlsConf, quicConf)
+				if err != nil {
+					return nil, err
+				}
+				quicConn = conn
+				return conn, nil
 			},
 			Logger: slog.Default(),
 		}
@@ -236,6 +278,10 @@ func main() {
 	if *verboseFlag {
 		slog.Info("HTTP Proto", "version", resp.Proto)
 		slog.Info("HTTP Status", "status", resp.Status)
+		if quicConn != nil {
+			version := quicConn.ConnectionState().Version
+			slog.Info("QUIC Version", "version", version.String(), "codepoint", fmt.Sprintf("0x%08x", uint32(version)))
+		}
 		for k, v := range resp.Header {
 			slog.Debug("Header", "key", k, "value", v)
 		}

--- a/x/tools/fetch/main.go
+++ b/x/tools/fetch/main.go
@@ -104,7 +104,7 @@ func main() {
 	transportFlag := flag.String("transport", "", "Transport config")
 
 	protoFlag := flag.String("proto", "h1", "HTTP version to use (h1, h2, h3)")
-	quicVersionsFlag := flag.String("quic-versions", defaultQUICVersions, "Ordered QUIC versions for h3 (1, 2, or a comma-separated list)")
+	quicVersionsFlag := flag.String("quic-versions", "", fmt.Sprintf("Ordered QUIC versions for h3 (1, 2, or a comma-separated list) (default %s)", defaultQUICVersions))
 	methodFlag := flag.String("method", "GET", "The HTTP method to use")
 	var headersFlag stringArrayFlagValue
 	flag.Var(&headersFlag, "H", "Raw HTTP Header line to add. It must not end in \\r\\n")
@@ -138,7 +138,7 @@ func main() {
 		flag.Usage()
 		os.Exit(1)
 	}
-	if *protoFlag != "h3" && *quicVersionsFlag != defaultQUICVersions {
+	if *protoFlag != "h3" && *quicVersionsFlag != "" {
 		slog.Error("-quic-versions requires -proto h3")
 		os.Exit(1)
 	}
@@ -204,7 +204,11 @@ func main() {
 			}
 		}
 	} else if *protoFlag == "h3" {
-		quicVersions, err := parseQUICVersions(*quicVersionsFlag)
+		quicVersionValue := *quicVersionsFlag
+		if quicVersionValue == "" {
+			quicVersionValue = defaultQUICVersions
+		}
+		quicVersions, err := parseQUICVersions(quicVersionValue)
 		if err != nil {
 			slog.Error("Invalid QUIC versions", "error", err)
 			os.Exit(1)

--- a/x/tools/fetch/main_test.go
+++ b/x/tools/fetch/main_test.go
@@ -27,14 +27,14 @@ func TestParseQUICVersions(t *testing.T) {
 		want    []quic.Version
 		wantErr bool
 	}{
-		{name: "v1", value: "v1", want: []quic.Version{quic.Version1}},
-		{name: "v2", value: "v2", want: []quic.Version{quic.Version2}},
-		{name: "ordered", value: "v2,v1", want: []quic.Version{quic.Version2, quic.Version1}},
-		{name: "codepoint", value: "0x6b3343cf", want: []quic.Version{quic.Version2}},
-		{name: "spaces and case", value: " V2, v1 ", want: []quic.Version{quic.Version2, quic.Version1}},
+		{name: "v1", value: "1", want: []quic.Version{quic.Version1}},
+		{name: "v2", value: "2", want: []quic.Version{quic.Version2}},
+		{name: "ordered", value: "2,1", want: []quic.Version{quic.Version2, quic.Version1}},
+		{name: "spaces", value: " 2, 1 ", want: []quic.Version{quic.Version2, quic.Version1}},
 		{name: "empty", value: "", wantErr: true},
-		{name: "unknown", value: "v3", wantErr: true},
-		{name: "duplicate", value: "v2,2", wantErr: true},
+		{name: "version name", value: "v1", wantErr: true},
+		{name: "unknown", value: "3", wantErr: true},
+		{name: "duplicate", value: "2,2", wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/x/tools/fetch/main_test.go
+++ b/x/tools/fetch/main_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/quic-go/quic-go"
+)
+
+func TestParseQUICVersions(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    []quic.Version
+		wantErr bool
+	}{
+		{name: "v1", value: "v1", want: []quic.Version{quic.Version1}},
+		{name: "v2", value: "v2", want: []quic.Version{quic.Version2}},
+		{name: "ordered", value: "v2,v1", want: []quic.Version{quic.Version2, quic.Version1}},
+		{name: "codepoint", value: "0x6b3343cf", want: []quic.Version{quic.Version2}},
+		{name: "spaces and case", value: " V2, v1 ", want: []quic.Version{quic.Version2, quic.Version1}},
+		{name: "empty", value: "", wantErr: true},
+		{name: "unknown", value: "v3", wantErr: true},
+		{name: "duplicate", value: "v2,2", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseQUICVersions(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseQUICVersions(%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseQUICVersions(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("parseQUICVersions(%q) = %v, want %v", tt.value, got, tt.want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary

- add an ordered `-quic-versions` option to the fetch CLI for HTTP/3
- support numeric selection of QUIC versions 1 and 2
- report the negotiated QUIC version and wire codepoint in verbose output
- add parser coverage and document the new option

### Motivation

The fetch tool currently cannot directly test QUIC v2 reachability or compare
version-specific network behavior. Applying the requested order to the HTTP/3
connection configuration allows forced-version and version-negotiation tests
while preserving the existing default preference.

### Testing

- `go test ./tools/fetch` from the `x` module
- forced v1 and v2 HTTP/3 requests against Caddy v2.11.4
- forced v1 and v2 requests against QUIC-Go's public interoperability server